### PR TITLE
added pm2 logrotate installation to setup_script

### DIFF
--- a/server/setup_server.sh
+++ b/server/setup_server.sh
@@ -41,6 +41,9 @@ else
     crontab crontab.tmp
     rm crontab.tmp
     
+    pm2 install pm2-logrotate
+    pm2 set pm2-logrotate:max_size 10M
+    pm2 set pm2-logrotate:compress true
     pm2 startup systemd
     pm2 start ecosystem.config.js --env production
 


### PR DESCRIPTION
PM2 built-in solution looks really promising https://github.com/keymetrics/pm2-logrotate.

We did a few calculations on the size of the log files we want.

Each line of the Brave-Heartbeat-Server log file is ~144 bytes, we get 1 line per 10 seconds per installation, which for the viv means ~4MB of logs per day. 

We probably don't care about analyzing log periods longer than two weeks, which would be ~56mb.
We chose a log max size of 10mb, and are ok with default retention of 30 files because this gives enough breathing room in case we want to a larger period.