### PR TITLE
Added ESLint for chatbot & made code compatible with recommended rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # BraveButtons [![Build Status](https://travis-ci.com/bravetechnologycoop/BraveButtons.svg?branch=master)](https://travis-ci.com/bravetechnologycoop/BraveButtons)
 
+# How to run the linter
+
+1. cd into the `chatbot` directory
+
+1. run `npm install`
+
+1. run `npx eslint .`
+
 # How to set up the network monitor on a raspberry pi:
 
 - format the SD card

--- a/chatbot/.eslintrc.json
+++ b/chatbot/.eslintrc.json
@@ -3,6 +3,7 @@
         "node": true,
         "es6": true
     },
+    "extends": "eslint:recommended",
     "globals": {
         "Atomics": "readonly",
         "SharedArrayBuffer": "readonly"

--- a/chatbot/.eslintrc.json
+++ b/chatbot/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+    "env": {
+        "node": true,
+        "es6": true
+    },
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
+    "rules": {
+        "indent": [
+            "error", 4, {"SwitchCase": 1}
+        ],
+        "linebreak-style": [
+            "error", "unix"
+        ]
+    }
+}

--- a/chatbot/SessionState.js
+++ b/chatbot/SessionState.js
@@ -2,10 +2,10 @@ const STATES = require('./SessionStateEnum.js');
 let moment = require('moment');
 
 const incidentTypes = {
-	'0': 'Accidental',
-	'1': 'Safer Use',
-	'2': 'Unsafe Guest',
-	'3': 'Overdose',
+    '0': 'Accidental',
+    '1': 'Safer Use',
+    '2': 'Unsafe Guest',
+    '3': 'Overdose',
     '4': 'Other'
 };
 

--- a/chatbot/SessionState.js
+++ b/chatbot/SessionState.js
@@ -27,7 +27,7 @@ class SessionState {
 
     advanceSession(messageText) {
 
-  	    let returnMessage;
+        let returnMessage;
 
         switch (this.state) {
             case STATES.STARTED:

--- a/chatbot/SessionState.js
+++ b/chatbot/SessionState.js
@@ -1,5 +1,4 @@
 const STATES = require('./SessionStateEnum.js');
-let moment = require('moment');
 
 const incidentTypes = {
     '0': 'Accidental',

--- a/chatbot/SessionState.js
+++ b/chatbot/SessionState.js
@@ -38,11 +38,12 @@ class SessionState {
                 this.state = STATES.WAITING_FOR_CATEGORY;
                 returnMessage = 'Now that you have responded, please reply with the number that best describes the incident:\n0 - accidental\n1 - safer use\n2 - unsafe guest\n3 - overdose\n4 - other';
                 break;
-            case STATES.WAITING_FOR_CATEGORY:
+            case STATES.WAITING_FOR_CATEGORY: {
                 let isValid = this.setIncidentType(messageText.trim());
                 this.state = isValid ? STATES.WAITING_FOR_DETAILS : STATES.WAITING_FOR_CATEGORY;
                 returnMessage = this.setIncidentType(messageText.trim()) ? 'Thank you. If you like, you can reply with any further details about the incident.' : 'Sorry, the incident type wasn\'t recognized. Please try again.';
                 break;
+            }
             case STATES.WAITING_FOR_DETAILS:
                 this.notes = messageText.trim();
                 this.state = STATES.COMPLETED;

--- a/chatbot/SessionStateEnum.js
+++ b/chatbot/SessionStateEnum.js
@@ -7,7 +7,7 @@ const STATES = {
     WAITING_FOR_DETAILS: "Waiting for incident details",
     COMPLETED: "Completed", 
     TIMED_OUT: "Timed out"
-  };
+};
 
 module.exports =
         Object.freeze(STATES); 

--- a/chatbot/db/db.js
+++ b/chatbot/db/db.js
@@ -7,7 +7,7 @@ const pool = new Pool({
     password: process.env.PG_PASSWORD
 })
 
-pool.on('error', (err, client) => {
+pool.on('error', (err) => {
     console.error('unexpected database error:', err)
 })
 

--- a/chatbot/package-lock.json
+++ b/chatbot/package-lock.json
@@ -216,6 +216,18 @@
         "negotiator": "0.6.1"
       }
     },
+    "acorn": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+      "dev": true
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -225,6 +237,15 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+      "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
       }
     },
     "ansi-regex": {
@@ -292,6 +313,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "async": {
       "version": "0.2.10",
@@ -387,6 +414,12 @@
         "write-file-atomic": "^2.4.2"
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -435,10 +468,31 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
     "cliui": {
       "version": "5.0.0",
@@ -620,6 +674,12 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
@@ -654,6 +714,15 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "dotenv": {
       "version": "6.1.0",
@@ -718,10 +787,168 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "eslint": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.2.tgz",
+      "integrity": "sha512-qMlSWJaCSxDFr8fBPvJM9kJwbazrhNcBU3+DszDW1OlEwKBBRWsJc7NJFelvwQpanHCR14cOLD41x8Eqvo3Nng==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.3",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
+          "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
+    "espree": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
@@ -793,6 +1020,28 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -807,6 +1056,30 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+      "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
     },
     "finalhandler": {
       "version": "1.1.1",
@@ -841,6 +1114,48 @@
       "requires": {
         "locate-path": "^3.0.0"
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
     },
     "foreground-child": {
       "version": "1.5.6",
@@ -888,6 +1203,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -919,6 +1240,15 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -1028,6 +1358,22 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -1049,6 +1395,69 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "inquirer": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
+      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
@@ -1065,11 +1474,26 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-ip": {
       "version": "2.0.0",
@@ -1078,6 +1502,12 @@
       "requires": {
         "ip-regex": "^2.0.0"
       }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -1254,6 +1684,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -1311,6 +1747,16 @@
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -1459,6 +1905,12 @@
         "mime-db": "~1.36.0"
       }
     },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1534,6 +1986,18 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
       "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -1549,6 +2013,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "node-json-db": {
@@ -1647,6 +2117,15 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -1657,10 +2136,30 @@
         "wordwrap": "~0.0.2"
       }
     },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "p-limit": {
@@ -1704,6 +2203,15 @@
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
       "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -1729,6 +2237,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
@@ -1868,10 +2382,22 @@
         "xtend": "^4.0.0"
       }
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.4",
@@ -1969,6 +2495,12 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
@@ -2032,6 +2564,16 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -2061,6 +2603,24 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/rootpath/-/rootpath-0.1.2.tgz",
       "integrity": "sha1-Wzeah9ypBum5HWkKWZQ5vvJn6ms="
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -2124,11 +2684,37 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
     },
     "source-map": {
       "version": "0.5.7",
@@ -2251,6 +2837,12 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-json-comments": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+      "dev": true
+    },
     "superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -2291,6 +2883,18 @@
         "has-flag": "^3.0.0"
       }
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      }
+    },
     "test-exclude": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
@@ -2319,10 +2923,25 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -2350,6 +2969,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
     },
     "tunnel-agent": {
@@ -2389,10 +3014,25 @@
         }
       }
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",
@@ -2471,6 +3111,12 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -2516,6 +3162,12 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -2538,6 +3190,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "2.4.3",

--- a/chatbot/package.json
+++ b/chatbot/package.json
@@ -21,6 +21,7 @@
     "twilio": "^3.33.2"
   },
   "devDependencies": {
+    "eslint": "^6.7.2",
     "mocha": "^5.2.0",
     "nyc": "^14.1.1"
   },

--- a/chatbot/server.js
+++ b/chatbot/server.js
@@ -297,12 +297,12 @@ app.post('/', jsonBodyParser, async (req, res) => {
                 res.status(400).send();
             }
             else {
+                let numPresses = 1
+
                 if(req.body.Type == 'double_click') {
                     numPresses = 2;
                 }
-                else {
-                    numPresses = 1
-                }
+
                 await handleValidRequest(button, numPresses)
                 res.status(200).send();
             }

--- a/chatbot/server.js
+++ b/chatbot/server.js
@@ -40,7 +40,7 @@ function log(logString) {
 }
 
 function getEnvVar(name) {
-	return process.env.NODE_ENV === 'test' ? process.env[name + '_TEST'] : process.env[name];
+    return process.env.NODE_ENV === 'test' ? process.env[name + '_TEST'] : process.env[name];
 }
 
 /**
@@ -48,8 +48,8 @@ Check if a request is valid based on the presence of required body properties
 **/
 function isValidRequest(req, properties) {
 
-	const hasAllProperties = (hasAllPropertiesSoFar, currentProperty) => hasAllPropertiesSoFar && req.body.hasOwnProperty(currentProperty);
-	return properties.reduce(hasAllProperties, true);
+    const hasAllProperties = (hasAllPropertiesSoFar, currentProperty) => hasAllPropertiesSoFar && req.body.hasOwnProperty(currentProperty);
+    return properties.reduce(hasAllProperties, true);
 }
 
 async function handleValidRequest(button, numPresses) {
@@ -58,28 +58,28 @@ async function handleValidRequest(button, numPresses) {
 
     let client = await db.beginTransaction()
 
-        let session = await db.getUnrespondedSessionWithButtonId(button.button_id, client)
+    let session = await db.getUnrespondedSessionWithButtonId(button.button_id, client)
         
-        if(session === null) {
-            session = await db.createSession(button.installation_id, button.button_id, button.unit, button.phone_number, numPresses, client)
-        }
-        else {
-            session.incrementButtonPresses(numPresses)
-            await db.saveSession(session, client)
-        }
+    if(session === null) {
+        session = await db.createSession(button.installation_id, button.button_id, button.unit, button.phone_number, numPresses, client)
+    }
+    else {
+        session.incrementButtonPresses(numPresses)
+        await db.saveSession(session, client)
+    }
 
-        if(needToSendButtonPressMessageForSession(session)) {
-            sendButtonPressMessageForSession(session)
-        }
+    if(needToSendButtonPressMessageForSession(session)) {
+        sendButtonPressMessageForSession(session)
+    }
 
     await db.commitTransaction(client)
 }
 
 async function handleTwilioRequest(req) {
 
-	let phoneNumber = req.body.From;
-	let buttonPhone = req.body.To;
-	let message = req.body.Body;
+    let phoneNumber = req.body.From;
+    let buttonPhone = req.body.To;
+    let message = req.body.Body;
 
     let session = await db.getMostRecentIncompleteSessionWithPhoneNumber(buttonPhone)
 
@@ -123,7 +123,7 @@ async function sendButtonPressMessageForSession(session) {
 async function sendTwilioMessage(toPhoneNumber, fromPhoneNumber, message) {
     try {
         await client.messages.create({from: fromPhoneNumber, body: message, to: toPhoneNumber})
-                             .then(message => log(message.sid))
+            .then(message => log(message.sid))
     }
     catch(err) {
         log(err)
@@ -343,15 +343,15 @@ app.post('/message', jsonBodyParser, async (req, res) => {
 let server;
 
 if (process.env.NODE_ENV === 'test') { // local http server for testing
-	server = app.listen(8000);
+    server = app.listen(8000);
 }
 else {
-	let httpsOptions = {
+    let httpsOptions = {
 	    key: fs.readFileSync(`/etc/letsencrypt/live/${getEnvVar('DOMAIN')}/privkey.pem`),
 	    cert: fs.readFileSync(`/etc/letsencrypt/live/${getEnvVar('DOMAIN')}/fullchain.pem`)
-	}
-	server = https.createServer(httpsOptions, app).listen(443)
-	log('brave server listening on port 443')
+    }
+    server = https.createServer(httpsOptions, app).listen(443)
+    log('brave server listening on port 443')
 }
 
 module.exports.server = server

--- a/chatbot/server.js
+++ b/chatbot/server.js
@@ -218,11 +218,11 @@ app.route('/login')
             password = req.body.password;
 
         if ((username === getEnvVar('WEB_USERNAME')) && (password === getEnvVar('PASSWORD'))) {
-        	req.session.user = username;
-        	res.redirect('/dashboard');
+            req.session.user = username;
+            res.redirect('/dashboard');
         } 
         else {
-        	res.redirect('/login');
+            res.redirect('/login');
         }
     });
 
@@ -346,8 +346,8 @@ if (process.env.NODE_ENV === 'test') { // local http server for testing
 }
 else {
     let httpsOptions = {
-	    key: fs.readFileSync(`/etc/letsencrypt/live/${getEnvVar('DOMAIN')}/privkey.pem`),
-	    cert: fs.readFileSync(`/etc/letsencrypt/live/${getEnvVar('DOMAIN')}/fullchain.pem`)
+        key: fs.readFileSync(`/etc/letsencrypt/live/${getEnvVar('DOMAIN')}/privkey.pem`),
+        cert: fs.readFileSync(`/etc/letsencrypt/live/${getEnvVar('DOMAIN')}/fullchain.pem`)
     }
     server = https.createServer(httpsOptions, app).listen(443)
     log('brave server listening on port 443')

--- a/chatbot/server.js
+++ b/chatbot/server.js
@@ -47,7 +47,7 @@ Check if a request is valid based on the presence of required body properties
 **/
 function isValidRequest(req, properties) {
 
-    const hasAllProperties = (hasAllPropertiesSoFar, currentProperty) => hasAllPropertiesSoFar && req.body.hasOwnProperty(currentProperty);
+    const hasAllProperties = (hasAllPropertiesSoFar, currentProperty) => hasAllPropertiesSoFar && Object.prototype.hasOwnProperty.call(req.body, currentProperty);
     return properties.reduce(hasAllProperties, true);
 }
 

--- a/chatbot/server.js
+++ b/chatbot/server.js
@@ -9,7 +9,6 @@ var session = require('express-session');
 const chalk = require('chalk')
 const Mustache = require('mustache')
 
-let SessionState = require('./SessionState.js')
 const STATES = require('./SessionStateEnum.js');
 require('dotenv').load();
 const db = require('./db/db.js')

--- a/chatbot/test/SessionStateTest.js
+++ b/chatbot/test/SessionStateTest.js
@@ -1,7 +1,11 @@
 let chai = require('chai');
+const expect = chai.expect;
+var beforeEach = require('mocha').beforeEach
+var describe = require('mocha').describe
+var it = require('mocha').it
+
 let SessionState = require('../SessionState.js');
 const STATES = require('../SessionStateEnum.js');
-const expect = chai.expect;
 
 describe('Session state manager', () => {
 

--- a/chatbot/test/SessionStateTest.js
+++ b/chatbot/test/SessionStateTest.js
@@ -5,59 +5,59 @@ const expect = chai.expect;
 
 describe('Session state manager', () => {
 
-        const sessionId = '12345'
-        const installationId = '67890'
-        const buttonId = '12345'
-        const unit = '1'
-        const phoneNumber = '+14206666969'
-        const createdAt = Date()
-        const updatedAt = Date()
+    const sessionId = '12345'
+    const installationId = '67890'
+    const buttonId = '12345'
+    const unit = '1'
+    const phoneNumber = '+14206666969'
+    const createdAt = Date()
+    const updatedAt = Date()
 
-		let state;
+    let state;
 
-		beforeEach(function() {
-			state = new SessionState(sessionId, installationId, buttonId, unit, phoneNumber, STATES.STARTED, 1, createdAt, updatedAt, null, null);
-		});
+    beforeEach(function() {
+        state = new SessionState(sessionId, installationId, buttonId, unit, phoneNumber, STATES.STARTED, 1, createdAt, updatedAt, null, null);
+    });
 
-		it('should start off with 1 button press', () => {
-			expect(state).to.have.property('numPresses');
-			expect(state.numPresses).to.deep.equal(1);
-		});
+    it('should start off with 1 button press', () => {
+        expect(state).to.have.property('numPresses');
+        expect(state.numPresses).to.deep.equal(1);
+    });
 
-		it('should increment properly', () => {
-			state.incrementButtonPresses(1);
-			expect(state.numPresses).to.deep.equal(2);
-			state.incrementButtonPresses(2);
-			expect(state.numPresses).to.deep.equal(4);
-		});
+    it('should increment properly', () => {
+        state.incrementButtonPresses(1);
+        expect(state.numPresses).to.deep.equal(2);
+        state.incrementButtonPresses(2);
+        expect(state.numPresses).to.deep.equal(4);
+    });
 
-		it('should advance the session when receiving an initial message', () => {
-            expect(state.state).to.deep.equal(STATES.STARTED)
-			state.advanceSession('ok');
-			expect(state.state).to.deep.equal(STATES.WAITING_FOR_CATEGORY);
-		});
+    it('should advance the session when receiving an initial message', () => {
+        expect(state.state).to.deep.equal(STATES.STARTED)
+        state.advanceSession('ok');
+        expect(state.state).to.deep.equal(STATES.WAITING_FOR_CATEGORY);
+    });
 
-		it('should advance the session when receiving an initial message (after a reminder has been sent)', () => {
-			state.state = STATES.WAITING_FOR_REPLY;
-			state.advanceSession('ok');
-			expect(state.state).to.deep.equal(STATES.WAITING_FOR_CATEGORY);
-		});
+    it('should advance the session when receiving an initial message (after a reminder has been sent)', () => {
+        state.state = STATES.WAITING_FOR_REPLY;
+        state.advanceSession('ok');
+        expect(state.state).to.deep.equal(STATES.WAITING_FOR_CATEGORY);
+    });
 
-		it('should advance the session when receiving a message categorizing the incident', () => {
-			state.state = STATES.WAITING_FOR_CATEGORY;
-			state.advanceSession('3');
-			expect(state.state).to.deep.equal(STATES.WAITING_FOR_DETAILS);
-		});
+    it('should advance the session when receiving a message categorizing the incident', () => {
+        state.state = STATES.WAITING_FOR_CATEGORY;
+        state.advanceSession('3');
+        expect(state.state).to.deep.equal(STATES.WAITING_FOR_DETAILS);
+    });
 
-		it('should advance the session when receiving a message categorizing the incident that contains whitespace', () => {
-			state.state = STATES.WAITING_FOR_CATEGORY;
-			state.advanceSession('3  ');
-			expect(state.state).to.deep.equal(STATES.WAITING_FOR_DETAILS);
-		});
+    it('should advance the session when receiving a message categorizing the incident that contains whitespace', () => {
+        state.state = STATES.WAITING_FOR_CATEGORY;
+        state.advanceSession('3  ');
+        expect(state.state).to.deep.equal(STATES.WAITING_FOR_DETAILS);
+    });
 
-		it('should not advance the session when receiving an invalid incident category', () => {
-			state.state = STATES.WAITING_FOR_CATEGORY;
-			state.advanceSession('fff');
-			expect(state.state).to.deep.equal(STATES.WAITING_FOR_CATEGORY);
-		});
+    it('should not advance the session when receiving an invalid incident category', () => {
+        state.state = STATES.WAITING_FOR_CATEGORY;
+        state.advanceSession('fff');
+        expect(state.state).to.deep.equal(STATES.WAITING_FOR_CATEGORY);
+    });
 });

--- a/chatbot/test/serverTest.js
+++ b/chatbot/test/serverTest.js
@@ -75,7 +75,7 @@ describe('Chatbot server', () => {
             await db.clearButtons()
             await db.clearInstallations()
             console.log('\n')
-	    });
+        });
 
         it('should return 400 to a request with an empty body', async () => {
             let response = await chai.request(server).post('/').send({});
@@ -134,8 +134,8 @@ describe('Chatbot server', () => {
 
             await Promise.all([
                 chai.request(server).post('/').send(unit1FlicRequest_SingleClick),
-		        chai.request(server).post('/').send(unit1FlicRequest_DoubleClick),
-			    chai.request(server).post('/').send(unit1FlicRequest_Hold)
+                chai.request(server).post('/').send(unit1FlicRequest_DoubleClick),
+                chai.request(server).post('/').send(unit1FlicRequest_Hold)
             ])
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
@@ -145,7 +145,7 @@ describe('Chatbot server', () => {
         it('should count button presses accurately during an active session', async () => {
 
             let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
-		    response = await chai.request(server).post('/').send(unit1FlicRequest_DoubleClick);
+            response = await chai.request(server).post('/').send(unit1FlicRequest_DoubleClick);
             response = await chai.request(server).post('/').send(unit1FlicRequest_Hold);
             expect(response).to.have.status(200);
 
@@ -181,7 +181,7 @@ describe('Chatbot server', () => {
             await db.clearButtons()
             await db.clearInstallations()
             console.log('\n')
-	    });
+        });
 
         after(async function() {
 
@@ -193,7 +193,7 @@ describe('Chatbot server', () => {
         })
 
         it('should return ok to a valid request', async () => {
-		    let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
             response = await chai.request(server).post('/message').send(twilioMessageUnit1_InitialStaffResponse);
             expect(response).to.have.status(200);
         });
@@ -210,7 +210,7 @@ describe('Chatbot server', () => {
 
         it('should return ok to a valid request and advance the session appropriately', async () => {
             
-		    let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
             expect(sessions.length).to.equal(1)

--- a/chatbot/test/serverTest.js
+++ b/chatbot/test/serverTest.js
@@ -1,10 +1,8 @@
 let chai = require('chai');
-let SessionState = require('../SessionState.js');
 const STATES = require('../SessionStateEnum.js');
 let imports = require('../server.js')
 let server = imports.server
 let db =imports.db
-let fs = require('fs');
 let chaiHttp = require('chai-http');
 chai.use(chaiHttp);
 const expect = chai.expect;
@@ -97,6 +95,7 @@ describe('Chatbot server', () => {
         it('should be able to create a valid session state from valid request', async () => {
 			
             let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            expect(response).to.have.status(200);
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
             expect(sessions.length).to.equal(1)
@@ -116,6 +115,7 @@ describe('Chatbot server', () => {
 
             let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
             response = await chai.request(server).post('/').send(unit2FlicRequest_SingleClick);
+            expect(response).to.have.status(200);
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
             expect(sessions.length).to.equal(1)
@@ -147,6 +147,7 @@ describe('Chatbot server', () => {
             let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
 		    response = await chai.request(server).post('/').send(unit1FlicRequest_DoubleClick);
             response = await chai.request(server).post('/').send(unit1FlicRequest_Hold);
+            expect(response).to.have.status(200);
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
             expect(sessions.length).to.equal(1)
@@ -249,6 +250,7 @@ describe('Chatbot server', () => {
 
         it('should send a message to the fallback phone number if enough time has passed without a response', async () => {
             let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            expect(response).to.have.status(200);
             await sleep(3501)
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
             expect(sessions.length).to.equal(1)

--- a/chatbot/test/serverTest.js
+++ b/chatbot/test/serverTest.js
@@ -23,30 +23,30 @@ describe('Chatbot server', () => {
     const installationFallbackPhoneNumber = '+12345678900'
 
     const unit1FlicRequest_SingleClick = {
-		'UUID': unit1UUID,
-		'Type': 'click'
-	};
+        'UUID': unit1UUID,
+        'Type': 'click'
+    };
 
-	const unit1FlicRequest_DoubleClick = {
-		'UUID': unit1UUID,
-		'Type': 'double_click'
-	};
+    const unit1FlicRequest_DoubleClick = {
+        'UUID': unit1UUID,
+        'Type': 'double_click'
+    };
 
-	const unit1FlicRequest_Hold = {
-		'UUID': unit1UUID,
-		'Type': 'hold'
-	};
+    const unit1FlicRequest_Hold = {
+        'UUID': unit1UUID,
+        'Type': 'hold'
+    };
 
-	const unit2FlicRequest_SingleClick = {
-		'UUID': unit2UUID,
-		'Type': 'click'
-	};
+    const unit2FlicRequest_SingleClick = {
+        'UUID': unit2UUID,
+        'Type': 'click'
+    };
 
-	const twilioMessageUnit1_InitialStaffResponse = {
-		'From': installationResponderPhoneNumber,
-		'Body': 'Ok',
-		'To': unit1PhoneNumber
-	};
+    const twilioMessageUnit1_InitialStaffResponse = {
+        'From': installationResponderPhoneNumber,
+        'Body': 'Ok',
+        'To': unit1PhoneNumber
+    };
 
     const twilioMessageUnit1_IncidentCategoryResponse = {
         'From': installationResponderPhoneNumber,
@@ -60,9 +60,9 @@ describe('Chatbot server', () => {
         'To': unit1PhoneNumber
     }
 
-	describe('POST request: button press', () => {
+    describe('POST request: button press', () => {
 
-		beforeEach(async function() {
+        beforeEach(async function() {
             await db.clearSessions()
             await db.clearButtons()
             await db.clearInstallations()
@@ -70,33 +70,33 @@ describe('Chatbot server', () => {
             let installations = await db.getInstallations()
             await db.createButton(unit1UUID, installations[0].id, "1", unit1PhoneNumber)
             await db.createButton(unit2UUID, installations[0].id, "2", unit2PhoneNumber)
-		});
+        });
 
-		afterEach(async function() {
+        afterEach(async function() {
             await db.clearSessions()
             await db.clearButtons()
             await db.clearInstallations()
             console.log('\n')
 	    });
 
-		it('should return 400 to a request with an empty body', async () => {
-			let response = await chai.request(server).post('/').send({});
-			expect(response).to.have.status(400);
-		});
+        it('should return 400 to a request with an empty body', async () => {
+            let response = await chai.request(server).post('/').send({});
+            expect(response).to.have.status(400);
+        });
 
-		it('should return 400 to a request with an unregistered button', async () => {
-			let response = await chai.request(server).post('/').send({'UUID': '666','Type': 'click'});
-			expect(response).to.have.status(400);
-		});
+        it('should return 400 to a request with an unregistered button', async () => {
+            let response = await chai.request(server).post('/').send({'UUID': '666','Type': 'click'});
+            expect(response).to.have.status(400);
+        });
 
-		it('should return 200 to a valid request', async () => {
-			let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
-			expect(response).to.have.status(200);
-		});
+        it('should return 200 to a valid request', async () => {
+            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            expect(response).to.have.status(200);
+        });
 
-		it('should be able to create a valid session state from valid request', async () => {
+        it('should be able to create a valid session state from valid request', async () => {
 			
-			let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
             expect(sessions.length).to.equal(1)
@@ -110,12 +110,12 @@ describe('Chatbot server', () => {
             expect(session.buttonId).to.deep.equal(unit1UUID);
             expect(session.unit).to.deep.equal('1');
             expect(session.numPresses).to.deep.equal(1);
-		});
+        });
 
-		it('should not confuse button presses from different rooms', async () => {
+        it('should not confuse button presses from different rooms', async () => {
 
-			let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
-			response = await chai.request(server).post('/').send(unit2FlicRequest_SingleClick);
+            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            response = await chai.request(server).post('/').send(unit2FlicRequest_SingleClick);
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
             expect(sessions.length).to.equal(1)
@@ -128,11 +128,11 @@ describe('Chatbot server', () => {
             expect(session.buttonId).to.deep.equal(unit1UUID);
             expect(session.unit).to.deep.equal('1');
             expect(session.numPresses).to.deep.equal(1);
-		});
+        });
 
         it('should only create one new session when receiving multiple presses from the same button', async () => {
 
-			await Promise.all([
+            await Promise.all([
                 chai.request(server).post('/').send(unit1FlicRequest_SingleClick),
 		        chai.request(server).post('/').send(unit1FlicRequest_DoubleClick),
 			    chai.request(server).post('/').send(unit1FlicRequest_Hold)
@@ -142,11 +142,11 @@ describe('Chatbot server', () => {
             expect(sessions.length).to.equal(1)
         });
 
-		it('should count button presses accurately during an active session', async () => {
+        it('should count button presses accurately during an active session', async () => {
 
-			let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
 		    response = await chai.request(server).post('/').send(unit1FlicRequest_DoubleClick);
-			response = await chai.request(server).post('/').send(unit1FlicRequest_Hold);
+            response = await chai.request(server).post('/').send(unit1FlicRequest_Hold);
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
             expect(sessions.length).to.equal(1)
@@ -160,12 +160,12 @@ describe('Chatbot server', () => {
             expect(session.buttonId).to.deep.equal(unit1UUID);
             expect(session.unit).to.deep.equal('1');
             expect(session.numPresses).to.deep.equal(4);
-		});
-	});
+        });
+    });
 
-	describe('POST request: twilio message', () => {
+    describe('POST request: twilio message', () => {
 
-		beforeEach(async function() {
+        beforeEach(async function() {
             await db.clearSessions()
             await db.clearButtons()
             await db.clearInstallations()
@@ -173,9 +173,9 @@ describe('Chatbot server', () => {
             let installations = await db.getInstallations()
             await db.createButton(unit1UUID, installations[0].id, "1", unit1PhoneNumber)
             await db.createButton(unit2UUID, installations[0].id, "2", unit2PhoneNumber)
-		});
+        });
 
-		afterEach(async function() {
+        afterEach(async function() {
             await db.clearSessions()
             await db.clearButtons()
             await db.clearInstallations()
@@ -191,23 +191,23 @@ describe('Chatbot server', () => {
             server.close()
         })
 
-		it('should return ok to a valid request', async () => {
+        it('should return ok to a valid request', async () => {
 		    let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
-			response = await chai.request(server).post('/message').send(twilioMessageUnit1_InitialStaffResponse);
-			expect(response).to.have.status(200);
-		});
+            response = await chai.request(server).post('/message').send(twilioMessageUnit1_InitialStaffResponse);
+            expect(response).to.have.status(200);
+        });
 
-		it('should return 400 to a request with incomplete data', async () => {
-			let response = await chai.request(server).post('/message').send({'Body': 'hi'});
-			expect(response).to.have.status(400);
-		});
+        it('should return 400 to a request with incomplete data', async () => {
+            let response = await chai.request(server).post('/message').send({'Body': 'hi'});
+            expect(response).to.have.status(400);
+        });
 
-		it('should return 400 to a request from an invalid phone number', async () => {
-			let response = await chai.request(server).post('/message').send({'Body': 'hi', 'From': '+16664206969'});
-			expect(response).to.have.status(400);
-		});
+        it('should return 400 to a request from an invalid phone number', async () => {
+            let response = await chai.request(server).post('/message').send({'Body': 'hi', 'From': '+16664206969'});
+            expect(response).to.have.status(400);
+        });
 
-		it('should return ok to a valid request and advance the session appropriately', async () => {
+        it('should return ok to a valid request and advance the session appropriately', async () => {
             
 		    let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
 
@@ -215,8 +215,8 @@ describe('Chatbot server', () => {
             expect(sessions.length).to.equal(1)
             expect(sessions[0].state, 'state after initial button press').to.deep.equal(STATES.STARTED);
 
-			response = await chai.request(server).post('/message').send(twilioMessageUnit1_InitialStaffResponse);
-			expect(response).to.have.status(200);
+            response = await chai.request(server).post('/message').send(twilioMessageUnit1_InitialStaffResponse);
+            expect(response).to.have.status(200);
 
             sessions = await db.getAllSessionsWithButtonId(unit1UUID)
             expect(sessions.length).to.equal(1)
@@ -236,8 +236,8 @@ describe('Chatbot server', () => {
             expect(sessions.length).to.equal(1)
             expect(sessions[0].state, 'state after staff have provided incident notes').to.deep.equal(STATES.COMPLETED) 
 
-			// now start a new session for a different unit
-			response = await chai.request(server).post('/').send(unit2FlicRequest_SingleClick);
+            // now start a new session for a different unit
+            response = await chai.request(server).post('/').send(unit2FlicRequest_SingleClick);
 
             sessions = await db.getAllSessionsWithButtonId(unit2UUID)
             expect(sessions.length).to.equal(1)

--- a/chatbot/test/serverTest.js
+++ b/chatbot/test/serverTest.js
@@ -1,11 +1,17 @@
 let chai = require('chai');
+let chaiHttp = require('chai-http');
+chai.use(chaiHttp);
+const expect = chai.expect;
+var describe = require('mocha').describe
+var it = require('mocha').it
+var beforeEach = require('mocha').beforeEach
+var afterEach = require('mocha').afterEach
+var after = require('mocha').after
+
 const STATES = require('../SessionStateEnum.js');
 let imports = require('../server.js')
 let server = imports.server
 let db =imports.db
-let chaiHttp = require('chai-http');
-chai.use(chaiHttp);
-const expect = chai.expect;
 require('dotenv').load();
 const sleep = (millis) => new Promise(resolve => setTimeout(resolve, millis))
 


### PR DESCRIPTION
I added ESLint and enabled the recommended rules, as well as a rule for indentation (4 spaces per indent). The list of available rules is [here](https://eslint.org/docs/rules/) - in the future we'll enable more, for example regarding semicolons, but I stopped here for now.

Instructions for running the linter are in the readme. In the future we'll also add the linter to our testing infrastructure so that it runs automatically.