### PR TITLE
Made a tool to help pair large numbers of buttons

### DIFF
--- a/pairing-tool/.gitignore
+++ b/pairing-tool/.gitignore
@@ -1,0 +1,2 @@
+*.csv
+pairing_tool_sqlite.db

--- a/pairing-tool/index.js
+++ b/pairing-tool/index.js
@@ -46,10 +46,14 @@ async function scanAndPairOneButton() {
                 const response = await prompt([unitQuestion, phoneNumberQuestion, confirmQuestion])
                 
                 if(response.confirmation) {
-                    csvWriter.write([bdAddr, response.unit, response.phoneNumber])
+                    client.getButtonInfo(bdAddr, (bdAddr, uuid, color, serialNumber) => {
+                        csvWriter.write([uuid, response.unit, response.phoneNumber])
+                        resolve()
+                    })
                 }
-
-                resolve()
+                else {
+                    resolve()
+                }
             }
         })
 

--- a/pairing-tool/index.js
+++ b/pairing-tool/index.js
@@ -1,0 +1,89 @@
+let flicLib = require('fliclib-linux-hci')
+const fs = require('fs')
+const CsvWriter = require('csv-write-stream')
+const { prompt } = require('enquirer')
+let FlicClient = flicLib.FlicClient
+let FlicScanWizard = flicLib.FlicScanWizard
+
+let client = new FlicClient('localhost', 5551)
+
+let csvWriter = CsvWriter({headers: ['button_id','unit','phone_number']})
+csvWriter.pipe(fs.createWriteStream(`./pairing-tool-output-${Math.random().toString(36).slice(-5)}.csv`))
+
+async function scanAndPairOneButton() {
+
+    let promise = new Promise((resolve, reject) => {
+
+        let wizard = new FlicScanWizard()
+        // wizard.on('foundPublicButton', (bdAddr, name) => console.log(`Found a public button with UUID ${bdAddr}, keep holding it down...`))
+        // wizard.on('buttonConnected', (bdAddr, name) => console.log(`Connected to a button with UUID ${bdAddr}, keep holding it down...`)) 
+        wizard.on('completed', async (result, bdAddr, name) => {
+            console.log(`Completed pairing for button ${bdAddr} with result: ${result}`)
+            if(result !== 'WizardSuccess') {
+                resolve()
+            }
+            else {
+
+                let unitQuestion = {
+                    type: 'input',
+                    name: 'unit',
+                    message: 'What is the unit for this new button?'
+                }
+
+                let phoneNumberQuestion = {
+                    type: 'input',
+                    name: 'phoneNumber',
+                    message: 'What is the phone number for this new button?'
+                }
+
+                let confirmQuestion = {
+                    type: 'confirm',
+                    name: 'confirmation',
+                    message: 'Create a button with the info above?'
+                }
+
+                const response = await prompt([unitQuestion, phoneNumberQuestion, confirmQuestion])
+                
+                if(response.confirmation) {
+                    csvWriter.write([bdAddr, response.unit, response.phoneNumber])
+                }
+
+                resolve()
+            }
+        })
+
+        client.addScanWizard(wizard)
+    })
+
+    await promise
+}
+
+async function runPairingTool() {
+
+    console.log('Welcome to the Brave Button pairing tool.')
+
+    while(true) {
+    
+        let continuePairingQuestion = {
+            type: 'confirm',
+            name: 'continuePairing',
+            message: 'Do you want to pair a button?'
+        }
+
+        const response = await prompt(continuePairingQuestion)
+
+        if(response.continuePairing) {
+            console.log('Hold down the button you want to pair...')
+            await scanAndPairOneButton()
+        }
+        else {
+            console.log('Pairing tool finished. Bye!')
+            csvWriter.end()
+            client.close()
+            break
+        }
+    }
+}
+
+client.on('ready', runPairingTool)
+client.on('error', (error) => console.log(error))

--- a/pairing-tool/index.js
+++ b/pairing-tool/index.js
@@ -7,8 +7,9 @@ let FlicScanWizard = flicLib.FlicScanWizard
 
 let client = new FlicClient('localhost', 5551)
 
+const outputFile = `./pairing-tool-output-${Math.random().toString(36).slice(-5)}.csv`
 let csvWriter = CsvWriter({headers: ['button_id','unit','phone_number']})
-csvWriter.pipe(fs.createWriteStream(`./pairing-tool-output-${Math.random().toString(36).slice(-5)}.csv`))
+csvWriter.pipe(fs.createWriteStream(outputFile))
 
 async function scanAndPairOneButton() {
 
@@ -79,6 +80,15 @@ async function runPairingTool() {
         else {
             console.log('Pairing tool finished. Bye!')
             csvWriter.end()
+
+            // put in a newline since the import script requires it 
+            try {
+                fs.appendFileSync(outputFile, '\n')
+            }
+            catch(e) {
+                console.log(`Error appending a newline to the output file: ${e}`)
+            }
+
             client.close()
             break
         }

--- a/pairing-tool/package-lock.json
+++ b/pairing-tool/package-lock.json
@@ -1,0 +1,156 @@
+{
+  "name": "pairing-tool",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-colors": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "csv-write-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/csv-write-stream/-/csv-write-stream-2.0.0.tgz",
+      "integrity": "sha1-/C2iGkjW6l+MF/3jnPuRHk8CkrA=",
+      "requires": {
+        "argparse": "^1.0.7",
+        "generate-object-property": "^1.0.0",
+        "ndjson": "^1.3.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.4.tgz",
+      "integrity": "sha512-pkYrrDZumL2VS6VBGDhqbajCM2xpkUNLuKfGPjfKaSIBKYopQbqEFyrOkRMIb2HDR/rO1kGhEt/5twBwtzKBXw==",
+      "requires": {
+        "ansi-colors": "^3.2.1"
+      }
+    },
+    "fliclib-linux-hci": {
+      "version": "git+https://github.com/bravetechnologycoop/fliclib-linux-hci.git#12b9bad21cdd2d35f169d9bdaf301242be3ddf19",
+      "from": "git+https://github.com/bravetechnologycoop/fliclib-linux-hci.git"
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "ndjson": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
+      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "^2.0.2"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    }
+  }
+}

--- a/pairing-tool/package.json
+++ b/pairing-tool/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pairing-tool",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Dave Schwartz",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "csv-write-stream": "^2.0.0",
+    "enquirer": "^2.3.4",
+    "fliclib-linux-hci": "git+https://github.com/bravetechnologycoop/fliclib-linux-hci.git"
+  }
+}

--- a/pairing-tool/start_flicd.sh
+++ b/pairing-tool/start_flicd.sh
@@ -1,0 +1,1 @@
+./node_modules/fliclib-linux-hci/bin/armv6l/flicd -df ./pairing_tool_sqlite.db


### PR DESCRIPTION
This tool runs on a Raspberry Pi and uses the Flic Linux SDK. It provides an interactive command-line process for pairing buttons and associating unit numbers and phone numbers with the UUID of each button. It outputs a CSV file in the format that the add_installation.sh script uses. Overall this greatly streamlines the process of preparing for a new installation.

The tool is tested up to the point of generating the CSV file, and seems to work well. The CSV files that the tool creates haven't been tested with the add_installation.sh script yet.