### PR TITLE
fixed an issue preventing server restart after certificate renewal

### DIFF
--- a/chatbot/setup_server.sh
+++ b/chatbot/setup_server.sh
@@ -49,8 +49,9 @@ else
     ./setup_postgresql.sh $installationName $responderNumber $fallbackNumber
 
     certbot certonly --standalone 
-
-    echo "0 0 * * 0 certbot renew --pre-hook 'env HOME=$HOME pm2 stop server' --post-hook 'env HOME=$HOME pm2 start server'" > crontab.tmp
+    
+    echo "PATH=/bin:/usr/bin:/usr/local/bin" > crontab.tmp
+    echo "0 0 * * 0 certbot renew --pre-hook 'env HOME=$HOME pm2 stop server' --post-hook 'env HOME=$HOME pm2 start server'" >> crontab.tmp
     crontab crontab.tmp
     rm crontab.tmp
     

--- a/heartbeat/setup_server.sh
+++ b/heartbeat/setup_server.sh
@@ -38,10 +38,14 @@ else
 
     certbot certonly --standalone 
 
-    echo "PATH=/bin:/usr/bin:/usr/local/bin" > crontab.tmp
-    echo "0 0 * * 0 certbot renew --pre-hook 'env HOME=$HOME pm2 stop BraveHeartbeatServer' --post-hook 'env HOME=$HOME pm2 start BraveHeartbeatServer'" >> crontab.tmp
-    crontab crontab.tmp
-    rm crontab.tmp
+    mkdir -p /var/log/brave
+    touch /var/log/brave/cron.log
+
+    # set up cron to have certbot renew certificates regularly, then send output to a log file
+    echo "
+    PATH=/bin:/usr/bin:/usr/local/bin
+    @weekly certbot renew --pre-hook 'env HOME=$HOME pm2 stop BraveHeartbeatServer' --post-hook 'env HOME=$HOME pm2 start BraveHeartbeatServer' >> /var/log/brave/cron.log 2>&1
+    " | crontab -
     
     pm2 install pm2-logrotate
     pm2 set pm2-logrotate:max_size 10M

--- a/heartbeat/setup_server.sh
+++ b/heartbeat/setup_server.sh
@@ -38,7 +38,8 @@ else
 
     certbot certonly --standalone 
 
-    echo "0 0 * * 0 certbot renew --pre-hook 'env HOME=$HOME pm2 stop BraveHeartbeatServer' --post-hook 'env HOME=$HOME pm2 start BraveHeartbeatServer'" > crontab.tmp
+    echo "PATH=/bin:/usr/bin:/usr/local/bin" > crontab.tmp
+    echo "0 0 * * 0 certbot renew --pre-hook 'env HOME=$HOME pm2 stop BraveHeartbeatServer' --post-hook 'env HOME=$HOME pm2 start BraveHeartbeatServer'" >> crontab.tmp
     crontab crontab.tmp
     rm crontab.tmp
     


### PR DESCRIPTION
Cron tasks execute with a minimal environment, meaning that the location of the pm2 executable was not on the PATH used by cron. This prevented the server process from restarting after certificate renewal took place.

I didn't catch this issue while testing the previous certificate renewal fix (#20) because I was copying the command from the crontab and executing it from a root shell, which had a different PATH setting. I tested this latest fix by changing the crontab to execute the command every minute instead of every week. In order to view the output of the cron jobs, I had to install a mail transfer agent (I used postfix, configured for local mail delivery only).

Relevant info:

https://askubuntu.com/questions/222512/cron-info-no-mta-installed-discarding-output-error-in-the-syslog
https://community.letsencrypt.org/t/problem-with-renew-certificates-the-request-message-was-malformed-method-not-allowed/107889/22