### PR TITLE
Add unmute API endpoint to Heartbeat (CU-baj2pv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ the code was deployed.
 - More logging to the Raspberry Pi (CU-behg93).
 - Instructions for interacting with remote managed database to README.
 - Instructions for performing database migrations to README.
+- `POST /unmute_system` API endpoint for the Heartbeat server (CU-baj2pv).
 
 ### Changed
 - "From" phone number used to send messages to the fallback phone is specified in `.env` (CU-6ed85y).
 - Local version of database setup script for use in TravisCI and local dev
 - db.js file now creates pool with remote database parameters
+- Heartbeat Dashboard displays whether a hub is muted or not (CU-baj2pv).
 
 ## [1.4.3] - 2020-08-18
 ### Added

--- a/heartbeat/dashboard.mst
+++ b/heartbeat/dashboard.mst
@@ -53,6 +53,7 @@ th, td {
                 <th>Last Seen (Flic)</th>
                 <th>Last Seen (Ping)</th>
                 <th>Last Seen (Heartbeat)</th>
+                <th>Muted?</th>
             </tr>
             {{#systems}}
             <tr>
@@ -60,6 +61,7 @@ th, td {
                 <td>{{flic_last_seen}}</td>
                 <td>{{flic_last_ping}}</td>
                 <td>{{heartbeat_last_seen}}</td>
+                <td>{{muted}}</td>
             </tr>
             {{/systems}}
         </table>

--- a/heartbeat/server.js
+++ b/heartbeat/server.js
@@ -104,6 +104,16 @@ app.post('/mute_system', jsonBodyParser, (req, res) => {
     res.status(200).send()
 })
 
+app.post('/unmute_system', jsonBodyParser, (req, res) => {
+    log('got a request to unmute system ' + req.body.system_id) 
+    db.update({ system_id: req.body.system_id }, { $set: { muted: false } }, {}, (err, numChanged) => {
+        if(err) {
+            log(err.message)
+        }
+    })
+    res.status(200).send()
+})
+
 app.get('/dashboard', (req, res) => {
     db.find({}, (err, docs) => {
         if(err) {

--- a/heartbeat/server.js
+++ b/heartbeat/server.js
@@ -146,7 +146,8 @@ app.get('/dashboard', (req, res) => {
                 system_name: doc.system_name,
                 flic_last_seen: flicLastSeenSecs.toString() + ' seconds ago',
                 flic_last_ping: flicLastPingSecs.toString() + ' seconds ago',
-                heartbeat_last_seen: heartbeatLastSeenSecs.toString() + ' seconds ago' 
+                heartbeat_last_seen: heartbeatLastSeenSecs.toString() + ' seconds ago',
+                muted: doc.muted ? 'Y' : 'N'
             })
         })
         

--- a/heartbeat/utils.py
+++ b/heartbeat/utils.py
@@ -23,6 +23,24 @@ def send_rename_request(server_url, system_id, name):
         print("error sending rename request")
         print(e)
 
+def send_mute_request(server_url, system_id):
+    payload = {"system_id": system_id}
+    try:
+        r = requests.post(server_url + r"/mute_system", json=payload)
+        print("response to mute request:", r.status_code, r.reason)
+    except Exception as e:
+        print("error sending mute request")
+        print(e)
+
+def send_unmute_request(server_url, system_id):
+    payload = {"system_id": system_id}
+    try:
+        r = requests.post(server_url + r"/unmute_system", json=payload)
+        print("response to unmute request:", r.status_code, r.reason)
+    except Exception as e:
+        print("error sending unmute request")
+        print(e)
+
 def send_heartbeat(server_url, system_id, flic_last_seen_secs):
     payload = {"system_id": system_id, "flic_last_seen_secs": flic_last_seen_secs}
     try:


### PR DESCRIPTION
Added a new endpoint called `POST unmute_system` that will unmute a muted system.

To help with testing this feature (and because I think it will be useful in real life), I also added a new "Muted?" column to the Heartbeat Dashboard that will display "Y" for systems that are muted and "N" for systems that are not muted.
![image](https://user-images.githubusercontent.com/1490437/92147225-a9bd7380-edcf-11ea-9782-d4d22f12b2e3.png)

While I was in there, I also noticed that there is a `POST hide_system` endpoint but no `POST show_system`. I'm wondering if this should be added as well. What do you think @schwarrrtz ?