### PR TITLE
Add environment variables to Travis YAML (CU-b4m32r)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,23 @@ matrix:
       # install database
       addons:
         postgresql: "9.5"
+     
+      # define environment variables 
+      env:
+        - WEB_USERNAME_TEST=TravisDashboardUsername
+        - PASSWORD_TEST=TravisDashboardPassword
+        - SECRET_TEST=TravisCookieSecret
+        - DOMAIN_TEST=chatbot-dev.brave.coop
+        - PG_USER=travis
+        - PG_PASSWORD=travispassword
+        # Test phone number (from https://www.twilio.com/docs/iam/test-credentials#test-sms-messages-parameters-From)
+        - RESPONDER_PHONE_TEST=+15005550006
+        # Test phone number (from https://www.twilio.com/docs/iam/test-credentials#test-sms-messages-parameters-From)
+        - STAFF_PHONE_TEST=+15005550006
+        # TWILIO_SID_TEST (from https://www.twilio.com/console/voice/project/test-credentials)
+        - secure: "PWfn0s7fHZMkn6M7iz3tfjbXcjkctNQewfb6NoiS7qT+6B6rgTNm9Sl4f/s3R2ygrRary9z/PO6FOUVp0Rk3X2j6PNT0zHyrd78Fu9USsXzm7tzct7D143S+nANNmwpe/PleP9Nfl7YzW6PdmB+Hp/4/BJKuyubBSH6BEDaZapLQRK5X6/klQoEnNyrGmhHMqem3HYlQkfqVuot1JRIXlxEo80U0wXQftKRqgGSr8WHImiMkMQvU2VRVe6sEmjNHFT6Mq0eZqLpX5Y9bmNdGkOMAN4hw16uXokqx4K/3M+CscNLT4RQLWJuFVYXN1eutZRmBGGUx5+CsXpgMVQVyd2qGIQtMytENNWHkMLnS/xSXzm3KzO8bJho7m+bliLIYm4I5vroFHe8dWbn9pUS6I9Az9YLSbjDHlTzUJvSGHOFe80XgsuVp5ZZpEg82u+h/HjDt7eUEqjPNPCbwqwEmK+AYfmkWNXArd5UkTF7vJclHwk0vv8YSZ/8OhbtktQN4P4BlJjLvzs44FxPIFyHdQaPYjfFGB+i0Gh/hU2fIqzujLCNtty6D3pNYvmmAsNDZkfyyR2Tt5bws4PVb7ze0H2qSELO3W5R194t/DN9SeG+afG+wHAxRjJantoiQEhvVxUg2cvn5AtntW0Z2s/ykhJo/eDSP64dbpFAJ8MHYpXA="
+        # TWILIO_TOKEN_TEST (from https://www.twilio.com/console/voice/project/test-credentials)
+        - secure: "xDH0U8Y9En68duGzZtVSTV8XDbUuu9ga0XEZUGQHLCki2mAYSVs+6O0iXz6o2FpiOq1VzP5mHzr+s5lfSM0dK2jQl7YapyDa9bWsMzdBYE9eubM2zD6DOx5oZEyfAMdyc+pEm53CUj++S62ut3YgKn/UoqiJwx/rm1Sjm2aDJ/rAQy+Pqzm+vEJiJVTIWsrawnQKCMqyKfQqYTGpAIli7TYiF217JRJi8b1i0PpV7BkhUaL8PO6ftmsZgwCoaEEr92HNi5JC0crDnrLKvgxao5Vt8IUJ06OZEVmnh/FpQDfbggJlFzplSQdPWlEY4lMyFp3KJRGJ88s3o/DMR14DrjHSUeB1rGztHlmXsIejb/rVBMEJBjQtJ0N9BvpUnu1a2Z/QP2v1JQOKDdGO4lzuq4ZIvEmKMm4LesJVDKnGiqK9TQJgRH2FSk+d+CFxIiXm3S1lzyceuHjs7NgTxjv33LmGJEKX8fkxp8ToP+SZGrnnLNPoTrfhSAHK37iJVmSYbPAv3by5f+n0IyqUrbhqUXgKx8GBBCLLXRnwAlohy5GBU/Uqj8pU2PHrKeQG8VCFsRYuLx5wqkFj2uJrODl5NB5U6zu6ynSPypGZct82vx9RpI0HWToZnFZf9ReXRaepYNfsH1SAo6br7oMZtI/MoSVVE3+jHuHsx1sUvfzMhTc="
 
       # setup database
       before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ the code was deployed.
 
 ## [Unreleased]
 ### Added
-- Changelog.
+- Changelog (CU-5wd4g9).
+- Environment variables to Travis config (CU-b4m32r).
 
 ## [1.4.3] - 2020-08-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -118,3 +118,17 @@ FROM migrations
 ORDER BY id;
 ```
 
+# How to add or change an encrypted Travis environment variable
+
+Reference: https://docs.travis-ci.com/user/environment-variables/#encrypting-environment-variables
+
+1. Download the Travis CLI `brew install travis` or `gem install travis`
+
+1. cd to anywhere in this repo
+
+1. For a given `VAR_NAME` that you want to have value `secret_value`, run
+   `travis encrypt --pro VAR_NAME=secret_value`
+   which will ask for your GitHub username and password and then
+   output your encrypted variable
+
+1. Copy the encrypted variable into `.travis.yml`


### PR DESCRIPTION
- So that we can remove them from the Travis UI
- This will help us keep our environment variables in sync with the code
- More robust in case Travis somehow forgets our variables in the UI
- Easier to find, because the Travis UI doesn't make it super obvious
where they are or how to change them
- Updated README to include instructions (@schwarrrtz and @mariocimet , are you able to make the `travis encrypt --pro ...` command work for you locally?