### PR TITLE
Add logging to help debugging (CU-behg93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ the code was deployed.
 ### Added
 - Changelog (CU-5wd4g9).
 - Environment variables to Travis config (CU-b4m32r).
+- More logging to the Raspberry Pi (CU-behg93).
 
 ## [1.4.3] - 2020-08-18
 ### Added

--- a/pi/sample_darkstat_html/log_ip.html
+++ b/pi/sample_darkstat_html/log_ip.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Hosts (darkstat eth0)</title>
+<meta name="generator" content="darkstat 3.0.719">
+<meta name="robots" content="noindex, noarchive">
+<link rel="stylesheet" href="../style.css" type="text/css">
+</head>
+<body>
+<div class="menu">
+<ul class="menu"><li class="label">darkstat 3.0.719</li><li><a href="../">graphs</a></li><li><a href="../hosts/">hosts</a></li><li><a href="https://unix4lyfe.org/darkstat/">homepage</a></li></ul>
+</div>
+<div class="content">
+<h2 class="pageheader">Hosts</h2>
+(1-30 of 458)<br>
+<table>
+<tr>
+ <th>IP</th>
+ <th>Hostname</th>
+ <th>MAC Address</th>
+ <th><a href="?sort=in">In</a></th>
+ <th><a href="?sort=out">Out</a></th>
+ <th><a href="?sort=total">Total</a></th>
+ <th><a href="?sort=lastseen">Last seen</a></th>
+</tr>
+<tr class="alt2">
+ <td><a href="./192.168.8.119/">192.168.8.119</a></td>
+ <td>raspberrypi</td>
+ <td><tt>00:00:00:00:00:00</tt></td>
+ <td class="num">1,161,289,982</td>
+ <td class="num">486,189,247</td>
+ <td class="num">1,647,479,229</td>
+ <td class="num">4 secs</td></tr>
+<tr class="alt1">
+ <td><a href="./012.345.67.890/">159.203.37.131</a></td>
+ <td>(none)</td>
+ <td><tt>00:00:00:00:00:01</tt></td>
+ <td class="num">485,198,012</td>
+ <td class="num">1,374,280,478</td>
+ <td class="num">1,859,478,490</td>
+ <td class="num">4 secs</td></tr>
+<tr class="alt2">
+ <td><a href="./192.168.8.114/">192.168.8.114</a></td>
+ <td>flic</td>
+ <td><tt>00:00:00:00:00:02</tt></td>
+ <td class="num">99,448,458</td>
+ <td class="num">64,825,724</td>
+ <td class="num">164,274,182</td>
+ <td class="num">1 hr, 3 mins, 26 secs</td></tr>
+<tr class="alt1">
+ <td><a href="./198.27.74.154/">198.27.74.154</a></td>
+ <td>cloudpvr.switch.ca</td>
+ <td><tt>00:00:00:00:00:03</tt></td>
+ <td class="num">972,952</td>
+ <td class="num">972,040</td>
+ <td class="num">1,944,992</td>
+ <td class="num">2 mins, 4 secs</td></tr>
+</table>
+&lt;&lt;&lt; prev page | <a href="?full=yes&sort=lastseen">full table</a> | <a href="?start=30&sort=lastseen">next page &gt;&gt;&gt;</a><br>
+</div>
+</body>
+</html>

--- a/pi/sample_darkstat_html/log_last_seen.html
+++ b/pi/sample_darkstat_html/log_last_seen.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Hosts (darkstat eth0)</title>
+<meta name="generator" content="darkstat 3.0.719">
+<meta name="robots" content="noindex, noarchive">
+<link rel="stylesheet" href="../style.css" type="text/css">
+</head>
+<body>
+<div class="menu">
+<ul class="menu"><li class="label">darkstat 3.0.719</li><li><a href="../">graphs</a></li><li><a href="../hosts/">hosts</a></li><li><a href="https://unix4lyfe.org/darkstat/">homepage</a></li></ul>
+</div>
+<div class="content">
+<h2 class="pageheader">Hosts</h2>
+(1-30 of 458)<br>
+<table>
+<tr>
+ <th>IP</th>
+ <th>Hostname</th>
+ <th>MAC Address</th>
+ <th><a href="?sort=in">In</a></th>
+ <th><a href="?sort=out">Out</a></th>
+ <th><a href="?sort=total">Total</a></th>
+ <th><a href="?sort=lastseen">Last seen</a></th>
+</tr>
+<tr class="alt2">
+ <td><a href="./192.168.8.119/">192.168.8.119</a></td>
+ <td>raspberrypi</td>
+ <td><tt>00:00:00:00:00:00</tt></td>
+ <td class="num">1,161,289,982</td>
+ <td class="num">486,189,247</td>
+ <td class="num">1,647,479,229</td>
+ <td class="num">4 secs</td></tr>
+<tr class="alt1">
+ <td><a href="./012.345.67.890/">159.203.37.131</a></td>
+ <td>(none)</td>
+ <td><tt>00:00:00:00:00:01</tt></td>
+ <td class="num">485,198,012</td>
+ <td class="num">1,374,280,478</td>
+ <td class="num">1,859,478,490</td>
+ <td class="num">4 secs</td></tr>
+<tr class="alt2">
+ <td><a href="./192.168.8.114/">192.168.8.114</a></td>
+ <td>flic</td>
+ <td><tt>00:00:00:00:00:02</tt></td>
+ <td class="num">99,448,458</td>
+ <td class="num">64,825,724</td>
+ <td class="num">164,274,182</td>
+ <td class="num">1 hr, 3 mins, 26 secs</td></tr>
+<tr class="alt1">
+ <td><a href="./198.27.74.154/">198.27.74.154</a></td>
+ <td>cloudpvr.switch.ca</td>
+ <td><tt>00:00:00:00:00:03</tt></td>
+ <td class="num">972,952</td>
+ <td class="num">972,040</td>
+ <td class="num">1,944,992</td>
+ <td class="num">2 mins, 4 secs</td></tr>
+</table>
+&lt;&lt;&lt; prev page | <a href="?full=yes&sort=lastseen">full table</a> | <a href="?start=30&sort=lastseen">next page &gt;&gt;&gt;</a><br>
+</div>
+</body>
+</html>

--- a/pi/test_heartbeat.py
+++ b/pi/test_heartbeat.py
@@ -30,6 +30,14 @@ class Test__parse_flic_last_seen_from_darkstat_html(object):
             with open(os.path.dirname(__file__) + '/sample_darkstat_html/never.html', 'r') as html_file:
                 html = html_file.read()
                 heartbeat.parse_flic_last_seen_from_darkstat_html(html, '00:00:00:00:00:02')
+    
+    def test_log_last_seen_when_darkstat_html_contains_flic_mac_address(self):
+        file_path = os.path.dirname(__file__) + '/sample_darkstat_html/log_last_seen.html'
+        with open(file_path, 'r') as html_file, unittest.mock.patch('heartbeat.logging') as mock_logging:
+            html = html_file.read()
+            heartbeat.parse_flic_last_seen_from_darkstat_html(html, '00:00:00:00:00:02')
+
+            mock_logging.info.assert_called_once_with('darkstat html contains flic last seen info:  <td><a href="./192.168.8.114/">192.168.8.114</a></td>  <td>flic</td>  <td><tt>00:00:00:00:00:02</tt></td>  <td class="num">1 hr, 3 mins, 26 secs</td></tr>')
 
 class Test__parse_flic_ip_from_darkstat_html(object):
 
@@ -38,10 +46,36 @@ class Test__parse_flic_ip_from_darkstat_html(object):
             html = html_file.read()
             assert heartbeat.parse_flic_ip_from_darkstat_html(html, '00:00:00:00:00:02') == '192.168.8.114'
 
+    def test_log_ip_when_darkstat_html_contains_flic_mac_address(self):
+        file_path = os.path.dirname(__file__) + '/sample_darkstat_html/log_ip.html'
+        with open(file_path, 'r') as html_file, unittest.mock.patch('heartbeat.logging') as mock_logging:
+            html = html_file.read()
+            heartbeat.parse_flic_ip_from_darkstat_html(html, '00:00:00:00:00:02')
+
+            mock_logging.info.assert_called_once_with('darkstat html contained flic IPv4 address:  <td><a href="./192.168.8.114/">192.168.8.114</a></td>  <td>flic</td>  <td><tt>00:00:00:00:00:02</tt></td>  <td class="num">1 hr, 3 mins, 26 secs</td></tr>')
+
 class Test__ping(object):
 
     def test_localhost(self):
         assert heartbeat.ping('localhost')
+    
+    def test_log_command(self):
+        with unittest.mock.patch('heartbeat.logging') as mock_logging:
+            heartbeat.ping('localhost')
+
+            mock_logging.info.assert_any_call('running: [\'ping\', \'-c\', \'1\', \'localhost\']')
+    
+    def test_log_when_successful(self):
+        with unittest.mock.patch('heartbeat.logging') as mock_logging:
+            heartbeat.ping('localhost')
+
+            mock_logging.info.assert_called_with('returned: 0')
+
+    def test_log_when_errored(self):
+        with unittest.mock.patch('heartbeat.logging') as mock_logging:
+            heartbeat.ping('invalid-ip')
+
+            mock_logging.info.assert_called_with('returned: 2')
 
 class Test__get_system_id_from_path(object):
 


### PR DESCRIPTION
- Seeing behaviour where Last Seen (Ping) is larger than Last Seen
(Flic), which doesn't make a lot of sense. So trying to see
exactly which IP address is being pinged, what the return code
from ping was, and which darkstat line provided the IP
- Also now log the FlicNotFoundError message from the object rather
than a generic message
- Added corresponding tests

I couldn't figure out how to test this on my local RPi because every time I plugged it in, I took down our local network. My guess is that because it was searching for the non-existent FlicHub every second, it was bogging down the system. Instead, I made mini python scripts to test just the functions that I changed locally to see that the logs turned out the way that I expected, and I added unit tests. 