### PR TITLE
Use .env variable for fallback "from" phone number instead of the phone number of the room whose button press was unanswered (CU-6ed85y)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
         - PG_PASSWORD=travispassword
         # Test phone number (from https://www.twilio.com/docs/iam/test-credentials#test-sms-messages-parameters-From)
         - RESPONDER_PHONE_TEST=+15005550006
+        - TWILIO_FALLBACK_FROM_NUMBER_TEST=+15005550006
         # Test phone number (from https://www.twilio.com/docs/iam/test-credentials#test-sms-messages-parameters-From)
         - STAFF_PHONE_TEST=+15005550006
         # TWILIO_SID_TEST (from https://www.twilio.com/console/voice/project/test-credentials)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ the code was deployed.
 - Environment variables to Travis config (CU-b4m32r).
 - More logging to the Raspberry Pi (CU-behg93).
 
+### Changed
+- "From" phone number used to send messages to the fallback phone is specified in `.env` (CU-6ed85y).
+
 ## [1.4.3] - 2020-08-18
 ### Added
 - Installation instructions to the README.

--- a/chatbot/.env.example
+++ b/chatbot/.env.example
@@ -12,6 +12,10 @@ TWILIO_SID_TEST=def456
 TWILIO_TOKEN=abc123
 TWILIO_TOKEN_TEST=def456
 
+# Fallback "from" phone number
+TWILIO_FALLBACK_FROM_NUMBER=+1888phonenumber
+TWILIO_FALLBACK_FROM_NUMBER_TEST=+15005550006
+
 # The username for logging into the dashboard
 WEB_USERNAME=username 
 WEB_USERNAME_TEST=username

--- a/chatbot/server.js
+++ b/chatbot/server.js
@@ -165,7 +165,10 @@ async function sendStaffAlertForSession(sessionId) {
         let installation = await db.getInstallationWithInstallationId(session.installationId)
 
         await client.messages
-            .create({from: session.phoneNumber, body: 'There has been an unresponded request at unit ' + session.unit.toString(), to: installation.fallbackPhoneNumber})
+            .create({
+                from: getEnvVar('TWILIO_FALLBACK_FROM_NUMBER'), 
+                body: 'There has been an unresponded request at ' + installation.name + ' unit ' + session.unit.toString(), to: installation.fallbackPhoneNumber
+            })
             .then(message => {
                 session.fallBackAlertTwilioStatus = message.status;
             })


### PR DESCRIPTION
- To ensure that these messages are not confusing for the fallback
staff, added the installation name to the message
- Unfortunately, the phone number that we are using in the tests for
the test rooms and for the test fallback from number need to be the
same because there is only one number that Twilio provides that will
succeed as a From number while using the test credentials. So I wasn't
able to write a test for this change

I pulled this change onto `chatbot-dev.brave.coop` and tested with my own phone as the responder and fallback phone. It worked as I expected.