### PR TITLE
[DO NOT MERGE] Call a console.log from brave-alert-lib (CU-baqucz)

### DIFF
--- a/chatbot/package-lock.json
+++ b/chatbot/package-lock.json
@@ -322,7 +322,7 @@
     },
     "async": {
       "version": "0.2.10",
-      "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
     },
     "asynckit": {
@@ -380,6 +380,10 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "brave-alert-lib": {
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#b4c15d44e6ac2c83cdb1a83088e1115fb1a61e22",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v0.1.0"
     },
     "browser-stdout": {
       "version": "1.3.1",

--- a/chatbot/package.json
+++ b/chatbot/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.18.3",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v0.1.0",
     "chai": "^4.2.0",
     "chai-http": "^4.2.0",
     "chalk": "^2.4.2",

--- a/chatbot/server.js
+++ b/chatbot/server.js
@@ -4,8 +4,9 @@ let https = require('https')
 let moment = require('moment-timezone')
 let bodyParser = require('body-parser')
 let jsonBodyParser = bodyParser.json()
-var cookieParser = require('cookie-parser');
-var session = require('express-session');
+let BraveAlerter = require('brave-alert-lib')
+var cookieParser = require('cookie-parser')
+var session = require('express-session')
 const chalk = require('chalk')
 const Mustache = require('mustache')
 
@@ -29,6 +30,9 @@ const dashboardTemplate = fs.readFileSync(`${__dirname}/dashboard.mst`, 'utf-8')
 
 app.use(bodyParser.urlencoded({extended: true}));
 app.use(express.static(__dirname));
+
+let braveAlerter = new BraveAlerter()
+braveAlerter.output()
 
 function log(logString) {
     if(process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
# DO NOT MERGE

- Just to prove that the `brave-alert-lib` can be included as a dependency of BraveButtons/chatbot using the `v0.1.0` tag and can be called from its code
   - You can see the `console.log` happening in the [test output in Travis](https://travis-ci.com/github/bravetechnologycoop/BraveButtons/jobs/379980378): "BraveAlertLib here" 
- Also removed some semi-colons that weren't consistent with our JS style