### PR TITLE
CU-byp1m3 + CU-3j6jj7 - Investigate Flakey Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,10 @@ matrix:
         - PASSWORD_TEST=TravisDashboardPassword
         - SECRET_TEST=TravisCookieSecret
         - DOMAIN_TEST=chatbot-dev.brave.coop
-        - PG_USER=brave
-        - PG_PASSWORD=travispassword
-        - PG_PORT=5433
-        - PG_HOST=localhost
+        - PG_USER_TEST=brave
+        - PG_PASSWORD_TEST=travispassword
+        - PG_PORT_TEST=5433
+        - PG_HOST_TEST=localhost
         # Test phone number (from https://www.twilio.com/docs/iam/test-credentials#test-sms-messages-parameters-From)
         - RESPONDER_PHONE_TEST=+15005550006
         - TWILIO_FALLBACK_FROM_NUMBER_TEST=+15005550006

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ matrix:
         - PG_PASSWORD_TEST=travispassword
         - PG_PORT_TEST=5433
         - PG_HOST_TEST=localhost
+        - PG_USER=brave
+        - PG_PASSWORD=travispassword
+        - PG_PORT=5433
+        - PG_HOST=localhost
         # Test phone number (from https://www.twilio.com/docs/iam/test-credentials#test-sms-messages-parameters-From)
         - RESPONDER_PHONE_TEST=+15005550006
         - TWILIO_FALLBACK_FROM_NUMBER_TEST=+15005550006

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ the code was deployed.
 - Upgrade handlebars (CU-c6rgqh).
 - Upgrade yargs-parser (CU-c6rgqh).
 
+### Changed
+- db.js now loads different environment variables depending on NODE_ENV test flag
+- Increased wait time in fallback message test to address race condition and reduce test flakiness
+
 ## [1.5.0] - 2020-09-04
 ### Added
 - Changelog (CU-5wd4g9).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ the code was deployed.
 - Upgrade yargs-parser (CU-c6rgqh).
 
 ### Changed
-- db.js now loads different environment variables depending on NODE_ENV test flag
-- Increased wait time in fallback message test to address race condition and reduce test flakiness
+- db.js now loads different environment variables depending on NODE_ENV test flag (CU-byp1m3).
+- Increased wait time in fallback message test to address race condition and reduce test flakiness (CU-3j6jj7).
 
 ## [1.5.0] - 2020-09-04
 ### Added

--- a/chatbot/.env.example
+++ b/chatbot/.env.example
@@ -34,12 +34,16 @@ DOMAIN_TEST=example.com
 
 # Username for connecting to postgres
 PG_USER=example
+PG_USER_TEST=example
 
 # Password for connecting to postgres
 PG_PASSWORD=examplepassword
+PG_PASSWORD_TEST=examplepassword
 
 # Remote host for managed postgres
 PG_HOST=examplehost
+PG_HOST_TEST=examplehost
 
 # Port for accessing remote database host
 PG_PORT=12345
+PG_PORT_TEST=12345

--- a/chatbot/db/db.js
+++ b/chatbot/db/db.js
@@ -1,26 +1,22 @@
 const STATES = require('../SessionStateEnum.js')
+const helpers = require('../helpers.js')
 const SessionState = require('../SessionState.js')
 const Installation = require('../Installation.js')
 const { Pool } = require('pg')
 require('dotenv').config();
 
 const pool = new Pool({
-    host: getEnvVar('PG_HOST'),
-    port: getEnvVar('PG_PORT'),
-    user: getEnvVar('PG_USER'),
-    database: getEnvVar('PG_USER'),
-    password: getEnvVar('PG_PASSWORD'),
+    host: helpers.getEnvVar('PG_HOST'),
+    port: helpers.getEnvVar('PG_PORT'),
+    user: helpers.getEnvVar('PG_USER'),
+    database: helpers.getEnvVar('PG_USER'),
+    password: helpers.getEnvVar('PG_PASSWORD'),
     ssl: true
 })
 
 pool.on('error', (err) => {
     console.error('unexpected database error:', err)
 })
-
-function getEnvVar(name) {
-    return process.env.NODE_ENV === 'test' ? process.env[name + '_TEST'] : process.env[name];
-}
-
 
 function createSessionFromRow(r) {
     return new SessionState(r.id, r.installation_id, r.button_id, r.unit, r.phone_number, r.state, r.num_presses, r.created_at, r.updated_at, r.incident_type, r.notes, r.fallback_alert_twilio_status)

--- a/chatbot/db/db.js
+++ b/chatbot/db/db.js
@@ -5,17 +5,22 @@ const { Pool } = require('pg')
 require('dotenv').config();
 
 const pool = new Pool({
-    host: process.env.PG_HOST,
-    port: process.env.PG_PORT,
-    user: process.env.PG_USER,
-    database: process.env.PG_USER,
-    password: process.env.PG_PASSWORD,
+    host: getEnvVar('PG_HOST'),
+    port: getEnvVar('PG_PORT'),
+    user: getEnvVar('PG_USER'),
+    database: getEnvVar('PG_USER'),
+    password: getEnvVar('PG_PASSWORD'),
     ssl: true
 })
 
 pool.on('error', (err) => {
     console.error('unexpected database error:', err)
 })
+
+function getEnvVar(name) {
+    return process.env.NODE_ENV === 'test' ? process.env[name + '_TEST'] : process.env[name];
+}
+
 
 function createSessionFromRow(r) {
     return new SessionState(r.id, r.installation_id, r.button_id, r.unit, r.phone_number, r.state, r.num_presses, r.created_at, r.updated_at, r.incident_type, r.notes, r.fallback_alert_twilio_status)

--- a/chatbot/helpers.js
+++ b/chatbot/helpers.js
@@ -1,0 +1,3 @@
+module.exports. getEnvVar = function getEnvVar(name) {
+    return process.env.NODE_ENV === 'test' ? process.env[name + '_TEST'] : process.env[name];
+}

--- a/chatbot/helpers.js
+++ b/chatbot/helpers.js
@@ -1,3 +1,3 @@
-module.exports. getEnvVar = function getEnvVar(name) {
+module.exports.getEnvVar = function getEnvVar(name) {
     return process.env.NODE_ENV === 'test' ? process.env[name + '_TEST'] : process.env[name];
 }

--- a/chatbot/test/serverTest.js
+++ b/chatbot/test/serverTest.js
@@ -258,7 +258,7 @@ describe('Chatbot server', () => {
         it('should send a message to the fallback phone number if enough time has passed without a response', async () => {
             let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
             expect(response).to.have.status(200);
-            await sleep(3501)
+            await sleep(4000)
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
             expect(sessions.length).to.equal(1)
             expect(sessions[0].state, 'state after reminder timeout has elapsed').to.deep.equal(STATES.WAITING_FOR_REPLY);


### PR DESCRIPTION
There's some documentation about how I investigated this in the clickup task, and test results for batch runs of tests. The only change here is to increase the amount of time that the test waits in between sending a test button press and checking the resulting session. This gives more time for the reminder and fallback message timers to expire, and for the several asynchronous calls that need to happen in between that and the message actually going out to conclude.

The timeouts add to 3000 milliseconds, so increasing from 3500 to 4000 doubles the extra time for those asynchronous calls.