### PR TITLE
ansible updates the comments in the remote access authorized_keys file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ the code was deployed.
 - Merged heartbeat and chatbot functionality into a single application (CU-bgke33).
 - Heartbeat text message alert now further details what triggered the alert (CU-crut3u).
 - Increased alert message threshold for Heartbeat and Flic (Darkstat) (CU-70bdx5).
+- In setup_pi.yaml, Ansible now updates the comment on the remote access authorized_keys file.
 
 ## [1.6.0] - 2020-10-05
 ### Added

--- a/ops/setup_pi.yaml
+++ b/ops/setup_pi.yaml
@@ -85,3 +85,4 @@
         user: brave
         state: present
         key: "{{ hostvars['OPENSSH_PUBLIC_KEY_HOLDER']['public_key'] }}"
+        comment: "{{ ansible_facts.date_time.iso8601 }} - {{ target_alias }}"


### PR DESCRIPTION
I tested this while setting up the Minna Lee range test hub, and it seems to work well.