### PR TITLE
A number of tweaks to make the button-press handling more consistent (CU-f0w9qm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ the code was deployed.
 ## [Unreleased]
 ### Changed
 - The time between the initial text message and the reminder is now 2 minutes (CU-eanm0j).
+- Allow calls to `POST /flic_button_press` without the `button-battery-level` header (CU-f0w9qm).
 
 ### Fixed
 - Double click handling (CU-f0w9qm).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ the code was deployed.
 ### Changed
 - The time between the initial text message and the reminder is now 2 minutes (CU-eanm0j).
 
+### Fixed
+- Double click handling (CU-f0w9qm).
+
 ## [2.0.0] - 2020-10-29
 ### Added
 - Deployment instructions in the README file (CU-d8rfw8).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ the code was deployed.
 ### Fixed
 - Double click handling (CU-f0w9qm).
 - Button press counting for POST requests to '/' to workaround a MS Flow bug (CU-f0w9qm).
+- Sent urgent text messages at the same frequency whether from '/' or '/flic_button_press' (CU-f0w9qm).
 
 ## [2.0.0] - 2020-10-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the code was deployed.
 
 ### Fixed
 - Double click handling (CU-f0w9qm).
+- Button press counting for POST requests to '/' to workaround a MS Flow bug (CU-f0w9qm).
 
 ## [2.0.0] - 2020-10-29
 ### Added

--- a/server/db/008-alternumpressestonumeric.sql
+++ b/server/db/008-alternumpressestonumeric.sql
@@ -1,0 +1,23 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 8;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        ALTER TABLE sessions
+        ALTER COLUMN num_presses
+        SET DATA TYPE numeric;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -3,7 +3,8 @@ const helpers = require('../helpers.js')
 const SessionState = require('../SessionState.js')
 const Installation = require('../Installation.js')
 const Hub = require('../Hub.js')
-const { Pool } = require('pg')
+const { Pool, types } = require('pg')
+
 require('dotenv').config();
 
 const pool = new Pool({
@@ -17,6 +18,10 @@ const pool = new Pool({
 
 pool.on('error', (err) => {
     console.error('unexpected database error:', err)
+})
+
+types.setTypeParser(types.builtins.NUMERIC, value => {
+    return parseFloat(value)
 })
 
 function createSessionFromRow(r) {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2307,9 +2307,9 @@
       }
     },
     "packet-reader": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
-      "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -2392,15 +2392,16 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.8.0.tgz",
-      "integrity": "sha512-yS3C9YD+ft0H7G47uU0eKajgTieggCXdA+Fxhm5G+wionY6kPBa8BEVDwPLMxQvkRkv3/LXiFEqjZm9gfxdW+g==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
+      "integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
       "requires": {
         "buffer-writer": "2.0.0",
-        "packet-reader": "0.3.1",
+        "packet-reader": "1.0.0",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "^2.0.4",
-        "pg-types": "~2.0.0",
+        "pg-packet-stream": "^1.1.0",
+        "pg-pool": "^2.0.10",
+        "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
       },
@@ -2422,29 +2423,34 @@
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
+    "pg-packet-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
+      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
+    },
     "pg-pool": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.6.tgz",
-      "integrity": "sha512-hod2zYQxM8Gt482q+qONGTYcg/qVcV32VHVPtktbBJs0us3Dj7xibISw0BAAXVMCzt8A/jhfJvpZaxUlqtqs0g=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
     },
     "pg-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.0.0.tgz",
-      "integrity": "sha512-THUD7gQll5tys+5eQ8Rvs7DjHiIC3bLqixk3gMN9Hu8UrCBAOjf35FoI39rTGGc3lM2HU/R+Knpxvd11mCwOMA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "requires": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
         "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.0",
+        "postgres-date": "~1.0.4",
         "postgres-interval": "^1.1.0"
       }
     },
     "pgpass": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
-      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
       "requires": {
-        "split": "^1.0.0"
+        "split2": "^3.1.1"
       }
     },
     "pify": {
@@ -2478,14 +2484,14 @@
       "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
     },
     "postgres-date": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
-      "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
     },
     "postgres-interval": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.2.tgz",
-      "integrity": "sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "requires": {
         "xtend": "^4.0.0"
       }
@@ -2892,12 +2898,24 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "requires": {
-        "through": "2"
+        "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "sprintf-js": {
@@ -3052,11 +3070,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -3325,9 +3338,9 @@
       "integrity": "sha1-kc1wiXdVNj66V8Et3uq0o0GmH2U="
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -190,6 +190,51 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.2.0.tgz",
+      "integrity": "sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
@@ -1794,6 +1839,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -1862,6 +1913,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.includes": {
@@ -2066,6 +2123,36 @@
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-json-db": {
       "version": "0.9.1",
@@ -2696,6 +2783,50 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.1.tgz",
+      "integrity": "sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.2.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "sinon-chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.5.0.tgz",
+      "integrity": "sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==",
       "dev": true
     },
     "slice-ansi": {

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,8 @@
   "devDependencies": {
     "eslint": "^7.11.0",
     "mocha": "^5.2.0",
+    "sinon": "^9.0.3",
+    "sinon-chai": "^3.5.0",
     "nyc": "^14.1.1"
   },
   "scripts": {

--- a/server/server.js
+++ b/server/server.js
@@ -55,20 +55,25 @@ function isValidRequest(req, properties) {
     return properties.reduce(hasAllProperties, true);
 }
 
-async function handleValidRequest(button, numPresses) {
-
-    log('UUID: ' + button.button_id.toString() + ' Unit: ' + button.unit.toString() + ' Presses: ' + numPresses.toString());
+async function handleValidRequest(button, numPresses, batteryLevel) {
+    log('UUID: ' + button.button_id.toString() + ' SerialNumber: ' + button.button_serial_number + ' Unit: ' + button.unit.toString() + ' Presses: ' + numPresses.toString() + ' BatteryLevel: ' + batteryLevel)
 
     let client = await db.beginTransaction()
 
     let session = await db.getUnrespondedSessionWithButtonId(button.button_id, client)
         
-    if(session === null) {
+    if (session === null) {
         session = await db.createSession(button.installation_id, button.button_id, button.unit, button.phone_number, numPresses, client)
     }
     else {
         session.incrementButtonPresses(numPresses)
         await db.saveSession(session, client)
+    }
+
+    if ((batteryLevel !== undefined) &&
+            (batteryLevel >= 0) &&
+            (batteryLevel <= 100)) {
+        await db.saveButtonBatteryLevel(button.button_serial_number, batteryLevel, client)
     }
 
     if(needToSendButtonPressMessageForSession(session)) {
@@ -294,24 +299,27 @@ app.get('/logout', (req, res) => {
     }
 });
 
-app.post('/flic_button_press', Validator.header(['button-serial-number','button-battery-level']).exists(), async (req, res) => {
+app.post('/flic_button_press', Validator.header(['button-serial-number']).exists(), async (req, res) => {
 
     try {
         const validationErrors = Validator.validationResult(req)
 
         if(validationErrors.isEmpty()){
-            let button = await db.getButtonWithSerialNumber(req.get('button-serial-number'))
+            const serialNumber = req.get('button-serial-number')
+            const batteryLevel = req.get('button-battery-level')
+
+            let button = await db.getButtonWithSerialNumber(serialNumber)
             if(button === null) {
-                log(`Bad request: Serial Number is not registered. Serial Number is ${req.get('button-serial-number')}`)
+                log(`Bad request: Serial Number is not registered. Serial Number is ${serialNumber}`)
                 res.status(400).send();
             }
             else {
-                await handleValidRequest(button, 1)
+                await handleValidRequest(button, 1, batteryLevel)
 
-                if(req.query.presses == 2) {
+                if (req.query.presses == 2) {
                     await handleValidRequest(button, 1)
                 }
-                await db.saveButtonBatteryLevel(req.get('button-serial-number'), req.get('button-battery-level'))
+
                 res.status(200).send();
             }
         }

--- a/server/server.js
+++ b/server/server.js
@@ -340,10 +340,10 @@ app.post('/', jsonBodyParser, async (req, res) => {
                 res.status(400).send();
             }
             else {
-                await handleValidRequest(button, 1)
+                await handleValidRequest(button, 0.5)
 
                 if (req.body.Type.startsWith('double')) {
-                    await handleValidRequest(button, 1)
+                    await handleValidRequest(button, 0.5)
                 }
 
                 res.status(200).send();

--- a/server/server.js
+++ b/server/server.js
@@ -306,13 +306,12 @@ app.post('/flic_button_press', Validator.header(['button-serial-number','button-
                 res.status(400).send();
             }
             else {
-                let numPresses = 1
+                await handleValidRequest(button, 1)
 
                 if(req.query.presses == 2) {
-                    numPresses = 2;
+                    await handleValidRequest(button, 1)
                 }
                 await db.saveButtonBatteryLevel(req.get('button-serial-number'), req.get('button-battery-level'))
-                await handleValidRequest(button, numPresses)
                 res.status(200).send();
             }
         }
@@ -341,13 +340,12 @@ app.post('/', jsonBodyParser, async (req, res) => {
                 res.status(400).send();
             }
             else {
-                let numPresses = 1
+                await handleValidRequest(button, 1)
 
                 if (req.body.Type.startsWith('double')) {
-                    numPresses = 2;
+                    await handleValidRequest(button, 1)
                 }
 
-                await handleValidRequest(button, numPresses)
                 res.status(200).send();
             }
         }

--- a/server/server.js
+++ b/server/server.js
@@ -113,18 +113,18 @@ async function handleTwilioRequest(req) {
 }
 
 async function needToSendButtonPressMessageForSession(session) {
-    return (session.numPresses === 1 || session.numPresses === 3 || session.numPresses % 5 === 0)
+    return (session.numPresses === 1 || session.numPresses === 2 || session.numPresses % 5 === 0)
 }
 
 async function sendButtonPressMessageForSession(session, client) {
     let installation = await db.getInstallationWithInstallationId(session.installationId, client)
 
     if (session.numPresses === 1) {
-        await sendTwilioMessage(installation.responderPhoneNumber, session.phoneNumber, 'There has been a request for help from Unit ' + session.unit.toString() + ' . Please respond "Ok" when you have followed up on the call.')
+        await sendTwilioMessage(installation.responderPhoneNumber, session.phoneNumber, 'There has been a request for help from Unit ' + session.unit.toString() + '. Please respond "Ok" when you have followed up on the call.')
         setTimeout(sendReminderMessageForSession, unrespondedSessionReminderTimeoutMillis, session.id)
         setTimeout(sendStaffAlertForSession, unrespondedSessionAlertTimeoutMillis, session.id)
     } 
-    else if (session.numPresses % 5 === 0 || session.numPresses === 3) {
+    else if (session.numPresses % 5 === 0 || session.numPresses === 2) {
         await sendTwilioMessage(installation.responderPhoneNumber, session.phoneNumber, 'This in an urgent request. The button has been pressed ' + session.numPresses.toString() + ' times. Please respond "Ok" when you have followed up on the call.')
     }
 }
@@ -163,7 +163,7 @@ async function sendStaffAlertForSession(sessionId) {
 
     let session = await db.getSessionWithSessionId(sessionId)
 
-    if (session === null) {         
+    if (session === null) {
         return
     }
 

--- a/server/server.js
+++ b/server/server.js
@@ -207,7 +207,8 @@ app.use((req, res, next) => {
 var sessionChecker = (req, res, next) => {
     if (req.session.user && req.cookies.user_sid) {
         res.redirect('/dashboard');
-    } else {
+    }
+    else {
         next();
     }
 };
@@ -343,7 +344,7 @@ app.post('/', jsonBodyParser, async (req, res) => {
             else {
                 let numPresses = 1
 
-                if(req.body.Type == 'double_click') {
+                if (req.body.Type.startsWith('double')) {
                     numPresses = 2;
                 }
 

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -6,3 +6,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USE
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/005-addincidentcategories.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/006-addhubs.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/007-addbatterymonitoring.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/008-alternumpressestonumeric.sql

--- a/server/test/serverTest.js
+++ b/server/test/serverTest.js
@@ -90,23 +90,34 @@ describe('Chatbot server', () => {
         });
 
         it('should return 400 to a request with an empty body', async () => {
-            let response = await chai.request(server).post('/').send({});
+            // Power Automate always sends two requests
+            let response = await chai.request(server).post('/').send({})
+            response = await chai.request(server).post('/').send({})
+
             expect(response).to.have.status(400);
         });
 
         it('should return 400 to a request with an unregistered button', async () => {
-            let response = await chai.request(server).post('/').send({'UUID': '666','Type': 'click'});
+            // Power Automate always sends two requests
+            let response = await chai.request(server).post('/').send({'UUID': '666','Type': 'click'})
+            response = await chai.request(server).post('/').send({'UUID': '666','Type': 'click'})
+
             expect(response).to.have.status(400);
         });
 
         it('should return 200 to a valid request', async () => {
-            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            // Power Automate always sends two requests
+            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+            response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+
             expect(response).to.have.status(200);
         });
 
         it('should be able to create a valid session state from valid request', async () => {
-			
-            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            // Power Automate always sends two requests
+            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+            response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+
             expect(response).to.have.status(200);
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
@@ -124,9 +135,14 @@ describe('Chatbot server', () => {
         });
 
         it('should not confuse button presses from different rooms', async () => {
+            // Power Automate always sends two requests
+            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+            response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
 
-            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
-            response = await chai.request(server).post('/').send(unit2FlicRequest_SingleClick);
+            // Power Automate always sends two requests
+            response = await chai.request(server).post('/').send(unit2FlicRequest_SingleClick)
+            response = await chai.request(server).post('/').send(unit2FlicRequest_SingleClick)
+
             expect(response).to.have.status(200);
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
@@ -145,9 +161,17 @@ describe('Chatbot server', () => {
         it('should only create one new session when receiving multiple presses from the same button', async () => {
 
             await Promise.all([
+                // Power Automate always sends two requests
                 chai.request(server).post('/').send(unit1FlicRequest_SingleClick),
+                chai.request(server).post('/').send(unit1FlicRequest_SingleClick),
+
+                // Power Automate always sends two requests
                 chai.request(server).post('/').send(unit1FlicRequest_DoubleClick),
-                chai.request(server).post('/').send(unit1FlicRequest_Hold)
+                chai.request(server).post('/').send(unit1FlicRequest_DoubleClick),
+
+                // Power Automate always sends two requests
+                chai.request(server).post('/').send(unit1FlicRequest_Hold),
+                chai.request(server).post('/').send(unit1FlicRequest_Hold),
             ])
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
@@ -155,10 +179,18 @@ describe('Chatbot server', () => {
         });
 
         it('should count button presses accurately during an active session', async () => {
+            // Power Automate always sends two requests
+            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+            response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
 
-            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
-            response = await chai.request(server).post('/').send(unit1FlicRequest_DoubleClick);
-            response = await chai.request(server).post('/').send(unit1FlicRequest_Hold);
+            // Power Automate always sends two requests
+            response = await chai.request(server).post('/').send(unit1FlicRequest_DoubleClick)
+            response = await chai.request(server).post('/').send(unit1FlicRequest_DoubleClick)
+
+            // Power Automate always sends two requests
+            response = await chai.request(server).post('/').send(unit1FlicRequest_Hold)
+            response = await chai.request(server).post('/').send(unit1FlicRequest_Hold)
+
             expect(response).to.have.status(200);
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
@@ -339,6 +371,8 @@ describe('Chatbot server', () => {
         it('should send the initial text message after a valid single click request to /', async () => {
             // Power Automate always sends two requests
             await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+            await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+
             expect(twilioClient.messages.create).to.be.calledOnce
         })
 
@@ -346,6 +380,7 @@ describe('Chatbot server', () => {
             // Power Automate always sends two requests
             await chai.request(server).post('/').send(unit1FlicRequest_DoubleClick)
             await chai.request(server).post('/').send(unit1FlicRequest_DoubleClick)
+
             expect(twilioClient.messages.create).to.be.calledOnce
         })
 
@@ -370,8 +405,11 @@ describe('Chatbot server', () => {
         })
 
         it('should return ok to a valid request', async () => {
-            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
-            response = await chai.request(server).post('/message').send(twilioMessageUnit1_InitialStaffResponse);
+            // Power Automate always sends two requests
+            await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+            await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+
+            let response = await chai.request(server).post('/message').send(twilioMessageUnit1_InitialStaffResponse);
             expect(response).to.have.status(200);
         });
 
@@ -386,14 +424,15 @@ describe('Chatbot server', () => {
         });
 
         it('should return ok to a valid request and advance the session appropriately', async () => {
-            
-            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            // Power Automate always sends two requests
+            await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+            await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
 
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
             expect(sessions.length).to.equal(1)
             expect(sessions[0].state, 'state after initial button press').to.deep.equal(STATES.STARTED);
 
-            response = await chai.request(server).post('/message').send(twilioMessageUnit1_InitialStaffResponse);
+            let response = await chai.request(server).post('/message').send(twilioMessageUnit1_InitialStaffResponse);
             expect(response).to.have.status(200);
 
             sessions = await db.getAllSessionsWithButtonId(unit1UUID)
@@ -415,7 +454,9 @@ describe('Chatbot server', () => {
             expect(sessions[0].state, 'state after staff have provided incident notes').to.deep.equal(STATES.COMPLETED) 
 
             // now start a new session for a different unit
-            response = await chai.request(server).post('/').send(unit2FlicRequest_SingleClick);
+            // Power Automate always sends two requests
+            await chai.request(server).post('/').send(unit2FlicRequest_SingleClick)
+            await chai.request(server).post('/').send(unit2FlicRequest_SingleClick)
 
             sessions = await db.getAllSessionsWithButtonId(unit2UUID)
             expect(sessions.length).to.equal(1)
@@ -426,7 +467,10 @@ describe('Chatbot server', () => {
         });
 
         it('should send a message to the fallback phone number if enough time has passed without a response', async () => {
-            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick);
+            // Power Automate always sends two requests
+            let response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+            response = await chai.request(server).post('/').send(unit1FlicRequest_SingleClick)
+
             expect(response).to.have.status(200);
             await sleep(4000)
             let sessions = await db.getAllSessionsWithButtonId(unit1UUID)

--- a/server/test/serverTest.js
+++ b/server/test/serverTest.js
@@ -36,7 +36,7 @@ describe('Chatbot server', () => {
 
     const unit1FlicRequest_DoubleClick = {
         'UUID': unit1UUID,
-        'Type': 'double_click'
+        'Type': 'double click'
     };
 
     const unit1FlicRequest_Hold = {

--- a/server/test/serverTest.js
+++ b/server/test/serverTest.js
@@ -423,12 +423,22 @@ describe('Chatbot server', () => {
             expect(twilioClient.messages.create).to.be.calledOnce
         })
 
-        it('should send the initial text message after a valid double click request to /', async () => {
+        it('should send the initial and urgent text messages after a valid double click request to /', async () => {
             // Power Automate always sends two requests
             await chai.request(server).post('/').send(unit1FlicRequest_DoubleClick)
             await chai.request(server).post('/').send(unit1FlicRequest_DoubleClick)
 
-            expect(twilioClient.messages.create).to.be.calledOnce
+            expect(twilioClient.messages.create).to.be.calledWith({
+                body: 'There has been a request for help from Unit 1. Please respond "Ok" when you have followed up on the call.',
+                from: sinon.match.any,
+                to: sinon.match.any,
+            })
+
+            expect(twilioClient.messages.create).to.be.calledWith({
+                body: 'This in an urgent request. The button has been pressed 2 times. Please respond "Ok" when you have followed up on the call.',
+                from: sinon.match.any, 
+                to: sinon.match.any,
+            })
         })
 
         it('should send the initial text message after a valid single click request to /flic_button_press', async () => {
@@ -441,14 +451,24 @@ describe('Chatbot server', () => {
             expect(twilioClient.messages.create).to.be.calledOnce
         })
 
-        it('should send the initial text message after a valid double click request to /flic_button_press', async () => {
+        it('should send the initial and urgent text messages after a valid double click request to /flic_button_press', async () => {
             await chai.request(server)
                 .post('/flic_button_press?presses=2')
                 .set('button-serial-number', unit1SerialNumber)
                 .set('button-battery-level', '100')
                 .send()
 
-            expect(twilioClient.messages.create).to.be.calledOnce
+            expect(twilioClient.messages.create).to.be.calledWith({
+                body: 'There has been a request for help from Unit 1. Please respond "Ok" when you have followed up on the call.',
+                from: sinon.match.any,
+                to: sinon.match.any,
+            })
+
+            expect(twilioClient.messages.create).to.be.calledWith({
+                body: 'This in an urgent request. The button has been pressed 2 times. Please respond "Ok" when you have followed up on the call.',
+                from: sinon.match.any, 
+                to: sinon.match.any,
+            })
         })
 
         it('should return ok to a valid request', async () => {


### PR DESCRIPTION
It might be easiest to go through this PR by going through the commits rather than looking at all the code at once.

There are four main changes:

1. When there is a **double click**, Power Automate / Flow sends the parameter `Type=double click`. However, in the code, we were looking for `double_click` (with an underscore). This means that when we received a request with `Type=double click`, we were treating it the same as a single click. This means that we might have missed the initial message for some urgent requests (they would still have received the reminder and fallback messages).

2. When a request comes in to `POST /` from Power Automate / Flow, this now counts it as only 0.5 of a button press. This will hopefully band-aid over the problem where it always **sends us two copies of each request**. This required a change in the DB to allow decimal values in the `num_presses` column, but I think it works. Unfortunately, at this time there are 38 rows in `sessions` that have an odd value in the `num_presses` column that are not the Princess Rooms (10 of them have `num_presses = 1`). This is out of the 1794 non-Princess Rooms sessions in that table.

3. **No longer require the `button-battery-level` header** in requests to `POST /flic_button_press`. I've seen cases where the Flic Internet Request doesn't send the button-battery-level header but everything else looks OK. I don't want to miss these presses, since there is no way to inform the resident that the button press did not result in a message. Therefore, this now allows these requests and just not updating the DB's button_battery_level value.

4. Now that we are counting each `POST /` as half a press. We can trust that the `num_presses` value is correct and should sent an **urgent text message when `numPresses == 2`**.

There are some other little changes to move things around, improve transaction handling, add/update tests, removing nearby semi-colons, etc.

This is available on `chatbot-dev` for testing.