### PR TITLE
Display all installations on dashboard (CU-fmudrh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ the code was deployed.
 
 ## [Unreleased]
 ### Added
-- Added is_active field to conditionally display only active active installations in dashboard (CU-fwpya5).
+- Added is_active field to conditionally display only active installations in dashboard (CU-fwpya5).
+
+### Fixed
+- All installations now displayed in dropdown on dashboard, and page is responsive (CU-fmudrh).
 
 ## [2.1.0] - 2020-11-12
 ### Changed

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -10,3 +10,4 @@ sessions.db
 sessionsTest.db
 .nyc_output
 coverage
+db/seeds.sql

--- a/server/chatbotDashboard.mst
+++ b/server/chatbotDashboard.mst
@@ -18,6 +18,23 @@ body {
     background-color: rgb(0, 184, 184);
 }
 
+.nav-item a {
+    color: rgb(247, 249, 250);
+}
+
+.dropdown,
+.dropdown-toggle,
+.dropdown-menu {
+	width: 100%;	
+}
+
+.nav-link.dropdown-item {
+    color: rgb(88, 88, 91);
+    overflow: hidden; 
+    white-space: nowrap; 
+    text-overflow: ellipsis;
+}    
+
 #navbar-brand{
     font-size: x-large;
     color: rgb(247, 249, 250);
@@ -77,20 +94,20 @@ th, td {
   </button>
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="navbar-nav">
+    <ul class="navbar-nav ml-auto">
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Dropdown
+          Installations
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
         {{#installations}}
-          <a class="nav-link" href="/dashboard/{{id}}">{{name}}</a>
+          <a class="nav-link dropdown-item" href="/dashboard/{{id}}">{{name}}</a>
         {{/installations}}
         </div>
       </li>
-      <li>
+      <li class="nav-item">
         <button class="btn btn-link btn-outline btn-logout">
-            <a href="/logout">Logout</a>
+            <a href="/logout">Log Out</a>
         </button>
     </li>
     </ul>

--- a/server/chatbotDashboard.mst
+++ b/server/chatbotDashboard.mst
@@ -66,14 +66,6 @@
             margin-top: 5%;
         }
 
-        .even-row {
-            background-color: rgb(247, 249, 250);
-        }
-
-        .odd-row {
-            background-color: rgb(233, 235, 236);
-        }
-
         .table-header {
             font-weight: 600;
         }
@@ -95,6 +87,12 @@
             width: 100%;
             white-space: pre-wrap;
             word-wrap: break-word;
+        }
+
+        .table>thead>tr>th,
+        .table>tbody>tr>th,
+        .table>tbody>tr>td {
+            border: none;
         }
 
         @media screen and (max-width: 770px) {
@@ -188,10 +186,11 @@
     <div class="content-area">
         <div class="content-wrapper">
             <h3>{{currentInstallationName}}</h3>
+            <br>
             <div class="table-responsive">
             <table class="table table-striped table-sm">
             <thead>
-                <tr class="table-header">
+                <tr class="table-header" scope="row">
                     <th scope="col">Unit</th>
                     <th scope="col">Presses</th>
                     <th scope="col">State</th>
@@ -204,7 +203,7 @@
             <tbody>
                 {{#recentSessions}}
                 <tr class="table-data {{class}}">
-                    <td>{{unit}}</td>
+                    <th scope="row" class="unit">{{unit}}</th>
                     <td>{{numPresses}}</td>
                     <td>{{state}}</td>
                     <td>{{incidentType}}</td>

--- a/server/chatbotDashboard.mst
+++ b/server/chatbotDashboard.mst
@@ -89,9 +89,9 @@ th, td {
         </div>
       </li>
       <li>
-      <form>
-        <button type="submit" class="btn btn-link btn-outline btn-logout" action="/logout" method="GET">Logout</button>
-      </form>
+        <button class="btn btn-link btn-outline btn-logout">
+            <a href="/logout">Logout</a>
+        </button>
     </li>
     </ul>
   </div>

--- a/server/chatbotDashboard.mst
+++ b/server/chatbotDashboard.mst
@@ -3,7 +3,9 @@
 
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 <style>
 
 body {
@@ -15,22 +17,27 @@ body {
 .navbar {
     background-color: rgb(0, 184, 184);
     color: rgb(247, 249, 250);
-    width: 100%;
-    height: 60px;
-    line-height: 60px;
+    height: auto;
+    max-height: auto;
 }
 
-.navbar span {
-    margin-left: 60px;
-    font-size: 24px;
-}
-
-.navbar a {
-    float: right;
-    margin-right: 60px;
+.nav-item {
     font-size: 20px;
-    text-decoration: none;
+
     color: white;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    height: auto;
+    max-height: auto;
+}
+
+.nav-item:hover {
+    overflow: visible;
+}
+
+#navbar-brand{
+    font-size: x-large;
 }
 
 .content-area {
@@ -76,16 +83,37 @@ th, td {
     word-wrap: break-word;
 }
 
+button {
+    border: 3px solid rgb(88, 88, 91);
+    color: white;
+}
+
+.navbar a:active {
+    color: white;
+}
+
 </style>
 </head>
 
 <body>
-    <div class="navbar">
-        <span>Brave Chatbot Dashboard</span>
+<nav class="navbar navbar-expand-xl navbar-dark">
+    <div class="container-fluid">
+  <a class="navbar-brand" id="navbar-brand">Brave Chatbot Dashboard</a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="nav navbar-nav">
         {{#installations}}
-            <a href="/dashboard/{{id}}">{{name}}</a>
+            <li class="nav-item">
+        <a class="nav-link" href="/dashboard/{{id}}">{{name}}</a>
+      </li>
         {{/installations}}
-    </div>
+    </ul>
+  </div>
+  </div>
+</nav>
     <div class="content-area">
         <div class="content-wrapper">
             <br><br>
@@ -121,5 +149,8 @@ th, td {
     }
     setInterval(reloadPage, 30000)
     </script>
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/server/chatbotDashboard.mst
+++ b/server/chatbotDashboard.mst
@@ -121,17 +121,8 @@
                 padding-right: 3%;
             }
 
-            .dropdown,
-            .dropdown-toggle,
-            .dropdown-menu {
-                width: 100%;	
-            }
-
             .nav-link.dropdown-item {
                 color: rgb(247, 249, 250);
-                overflow: hidden; 
-                white-space: nowrap; 
-                text-overflow: ellipsis;
                 text-align: right;
             }
 
@@ -158,65 +149,66 @@
 
 <body>
     <nav class="navbar navbar-expand-md">
-    <a class="navbar-brand" id="navbar-brand">Brave Chatbot Dashboard</a>
-    <button class="navbar-toggler navbar-dark" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
+        <a class="navbar-brand" id="navbar-brand">Brave Chatbot Dashboard</a>
+        <button class="navbar-toggler navbar-dark" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
 
-    <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav ml-auto">
-        <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Installations
-            </a>
-            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            {{#installations}}
-            <a class="nav-link dropdown-item" href="/dashboard/{{id}}">{{name}}</a>
-            {{/installations}}
-            </div>
-        </li>
-        <li class="nav-item">
-            <button class="btn btn-logout">
-                <a href="/logout" class="text-decoration-none">Log Out</a>
-            </button>
-        </li>
-        </ul>
-    </div>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav ml-auto">
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Installations
+                </a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                    {{#installations}}
+                        <a class="nav-link dropdown-item" href="/dashboard/{{id}}">{{name}}</a>
+                    {{/installations}}
+                </div>
+            </li>
+            <li class="nav-item">
+                <button class="btn btn-logout">
+                    <a href="/logout" class="text-decoration-none">Log Out</a>
+                </button>
+            </li>
+            </ul>
+        </div>
     </nav>
     <div class="content-area">
         <div class="content-wrapper">
             <h3>{{currentInstallationName}}</h3>
             <br>
             <div class="table-responsive">
-            <table class="table table-striped table-sm">
-            <thead>
-                <tr class="table-header" scope="row">
-                    <th scope="col">Unit</th>
-                    <th scope="col">Presses</th>
-                    <th scope="col">State</th>
-                    <th scope="col">Category</th>
-                    <th scope="col">Notes</th>
-                    <th scope="col">Started At</th>
-                    <th scope="col">Updated At</th>
-                </tr>
-            </thead>
-            <tbody>
-                {{#recentSessions}}
-                <tr class="table-data {{class}}">
-                    <th scope="row" class="unit">{{unit}}</th>
-                    <td>{{numPresses}}</td>
-                    <td>{{state}}</td>
-                    <td>{{incidentType}}</td>
-                    <td>{{notes}}</td>
-                    <td>{{createdAt}}</td>
-                    <td>{{updatedAt}}</td>
-                </tr>
-                {{/recentSessions}}
-            </tbody>
-            </table>
+                <table class="table table-striped table-sm">
+                    <thead>
+                        <tr class="table-header" scope="row">
+                            <th scope="col">Unit</th>
+                            <th scope="col">Presses</th>
+                            <th scope="col">State</th>
+                            <th scope="col">Category</th>
+                            <th scope="col">Notes</th>
+                            <th scope="col">Started At</th>
+                            <th scope="col">Updated At</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{#recentSessions}}
+                            <tr class="table-data {{class}}">
+                                <th scope="row" class="unit">{{unit}}</th>
+                                <td>{{numPresses}}</td>
+                                <td>{{state}}</td>
+                                <td>{{incidentType}}</td>
+                                <td>{{notes}}</td>
+                                <td>{{createdAt}}</td>
+                                <td>{{updatedAt}}</td>
+                            </tr>
+                        {{/recentSessions}}
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>
+    
     <script>
         function reloadPage() {
             location.reload(true)

--- a/server/chatbotDashboard.mst
+++ b/server/chatbotDashboard.mst
@@ -16,28 +16,11 @@ body {
 
 .navbar {
     background-color: rgb(0, 184, 184);
-    color: rgb(247, 249, 250);
-    height: auto;
-    max-height: auto;
-}
-
-.nav-item {
-    font-size: 20px;
-
-    color: white;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    height: auto;
-    max-height: auto;
-}
-
-.nav-item:hover {
-    overflow: visible;
 }
 
 #navbar-brand{
     font-size: x-large;
+    color: rgb(247, 249, 250);
 }
 
 .content-area {
@@ -83,35 +66,34 @@ th, td {
     word-wrap: break-word;
 }
 
-button {
-    border: 3px solid rgb(88, 88, 91);
-    color: white;
-}
-
-.navbar a:active {
-    color: white;
-}
-
 </style>
 </head>
 
 <body>
-<nav class="navbar navbar-expand-xl navbar-dark">
-    <div class="container-fluid">
+<nav class="navbar navbar-expand-sm">
   <a class="navbar-brand" id="navbar-brand">Brave Chatbot Dashboard</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="nav navbar-nav">
+    <ul class="navbar-nav">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Dropdown
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
         {{#installations}}
-            <li class="nav-item">
-        <a class="nav-link" href="/dashboard/{{id}}">{{name}}</a>
-      </li>
+          <a class="nav-link" href="/dashboard/{{id}}">{{name}}</a>
         {{/installations}}
+        </div>
+      </li>
+      <li>
+      <form>
+        <button type="submit" class="btn btn-link btn-outline btn-logout" action="/logout" method="GET">Logout</button>
+      </form>
+    </li>
     </ul>
-  </div>
   </div>
 </nav>
     <div class="content-area">
@@ -143,14 +125,15 @@ button {
             </table>
         </div>
     </div>
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+
     <script>
     function reloadPage() {
         location.reload(true)
     }
     setInterval(reloadPage, 30000)
     </script>
-    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/server/chatbotDashboard.mst
+++ b/server/chatbotDashboard.mst
@@ -2,117 +2,177 @@
 <html lang="en">
 
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-<style>
+    <title>Brave Chatbot Dashboard</title>
 
-body {
-    background-color: rgb(247, 249, 250);
-    margin: 0px;
-    font-family: 'Montserrat', sans-serif;
-}
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-.navbar {
-    background-color: rgb(0, 184, 184);
-}
+    <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 
-.nav-item a {
-    color: rgb(247, 249, 250);
-}
+    <style>
 
-.dropdown,
-.dropdown-toggle,
-.dropdown-menu {
-	width: 100%;	
-}
+        body {
+            background-color: rgb(247, 249, 250);
+            margin: 0px;
+            font-family: 'Montserrat', sans-serif;
+            font-size: 1em;
+        }
 
-.nav-link.dropdown-item {
-    color: rgb(88, 88, 91);
-    overflow: hidden; 
-    white-space: nowrap; 
-    text-overflow: ellipsis;
-}    
+        .navbar-toggler {
+            border: 2px solid rgba(255, 255, 255, .4);
+            border-radius: 5px;
+        }
 
-#navbar-brand{
-    font-size: x-large;
-    color: rgb(247, 249, 250);
-}
+        .navbar {
+            background-color: rgb(0, 184, 184);
+        }
 
-.content-area {
-    background-color: rgb(247, 249, 250);
-    color: rgb(88, 88, 91);
-}
+        .nav-item a {
+            color: rgb(247, 249, 250);
+        }
 
-.content-wrapper {
-    margin-left: 60px;
-    margin-right: 60px;
-    margin-top: 20px;
-}
+        .dropdown,
+        .dropdown-toggle,
+        .dropdown-menu {
+            width: 100%;	
+        }
 
-.even-row {
-    background-color: rgb(247, 249, 250);
-}
+        .nav-link.dropdown-item {
+            color: rgb(88, 88, 91);
+            overflow: hidden; 
+            white-space: nowrap; 
+            text-overflow: ellipsis;
+        }    
 
-.odd-row {
-    background-color: rgb(233, 235, 236);
-}
+        #navbar-brand {
+            font-size: x-large;
+            color: rgb(247, 249, 250);
+        }
 
-.table-header {
-    font-weight: 600;
-}
+        .content-area {
+            background-color: rgb(247, 249, 250);
+            color: rgb(88, 88, 91);
+        }
 
-.table-data {
-    font-weight: 400;
-}
+        .content-wrapper {
+            margin-left: 60px;
+            margin-right: 60px;
+            margin-top: 20px;
+        }
 
-table {
-    table-layout: fixed;
-    width: 100%;
-    border-collapse: collapse;
-    border-spacing: 5px 5px;
-}
+        .even-row {
+            background-color: rgb(247, 249, 250);
+        }
 
-th, td {
-    text-align: left;
-    max-width: 400px;
-    height: 40px;
-    width: 100%;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-}
+        .odd-row {
+            background-color: rgb(233, 235, 236);
+        }
 
-</style>
+        .table-header {
+            font-weight: 600;
+        }
+
+        .table-data {
+            font-weight: 400;
+        }
+
+        table {
+            table-layout: fixed;
+            width: 100%;
+            border-collapse: collapse;
+            border-spacing: 5px 5px;
+        }
+
+        th, td {
+            text-align: left;
+            max-width: 400px;
+            height: 40px;
+            width: 100%;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+        }
+
+        @media screen and (max-width: 770px) {
+
+            .nav-item {
+                text-align: right;
+            }
+
+            #navbar-brand {
+                font-size: 1.25em;
+            }
+
+            .dropdown-menu {
+                background-color: rgb(0, 184, 184);
+                border: none;
+                padding-right: 3%;
+            }
+
+            .dropdown,
+            .dropdown-toggle,
+            .dropdown-menu {
+                width: 100%;	
+            }
+
+            .nav-link.dropdown-item {
+                color: rgb(247, 249, 250);
+                overflow: hidden; 
+                white-space: nowrap; 
+                text-overflow: ellipsis;
+                text-align: right;
+            }
+
+            .nav-link.dropdown-item:hover {
+                color: white;
+                background-color: transparent;
+            }
+
+            .dropdown-menu.show {
+                padding-top: 0%;
+            }
+
+            .btn-logout {
+                padding-right: 0%;
+                font-weight: 700;
+            }
+
+            h3 {
+                font-size: 1.2em;
+                font-weight: 900;
+            }    
+        }
+
+    </style>
 </head>
 
 <body>
-<nav class="navbar navbar-expand-sm">
-  <a class="navbar-brand" id="navbar-brand">Brave Chatbot Dashboard</a>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
+    <nav class="navbar navbar-expand-md">
+    <a class="navbar-brand" id="navbar-brand">Brave Chatbot Dashboard</a>
+    <button class="navbar-toggler navbar-dark" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
 
-  <div class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="navbar-nav ml-auto">
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Installations
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-        {{#installations}}
-          <a class="nav-link dropdown-item" href="/dashboard/{{id}}">{{name}}</a>
-        {{/installations}}
-        </div>
-      </li>
-      <li class="nav-item">
-        <button class="btn btn-link btn-outline btn-logout">
-            <a href="/logout">Log Out</a>
-        </button>
-    </li>
-    </ul>
-  </div>
-</nav>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav ml-auto">
+        <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Installations
+            </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            {{#installations}}
+            <a class="nav-link dropdown-item" href="/dashboard/{{id}}">{{name}}</a>
+            {{/installations}}
+            </div>
+        </li>
+        <li class="nav-item">
+            <button class="btn btn-link btn-outline btn-logout">
+                <a href="/logout">Log Out</a>
+            </button>
+        </li>
+        </ul>
+    </div>
+    </nav>
     <div class="content-area">
         <div class="content-wrapper">
             <br><br>
@@ -142,15 +202,15 @@ th, td {
             </table>
         </div>
     </div>
+    <script>
+        function reloadPage() {
+            location.reload(true)
+        }
+        setInterval(reloadPage, 30000)
+    </script>
+    
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-
-    <script>
-    function reloadPage() {
-        location.reload(true)
-    }
-    setInterval(reloadPage, 30000)
-    </script>
 </body>
 </html>

--- a/server/chatbotDashboard.mst
+++ b/server/chatbotDashboard.mst
@@ -16,7 +16,6 @@
             background-color: rgb(247, 249, 250);
             margin: 0px;
             font-family: 'Montserrat', sans-serif;
-            font-size: 1em;
         }
 
         .navbar-toggler {
@@ -24,8 +23,9 @@
             border-radius: 5px;
         }
 
-        .navbar {
+        .navbar, .btn-logout {
             background-color: rgb(0, 184, 184);
+            font-size: 20px;
         }
 
         .nav-item a {
@@ -43,10 +43,15 @@
             overflow: hidden; 
             white-space: nowrap; 
             text-overflow: ellipsis;
+        }
+
+        .btn-logout, .btn-logout > a {
+            width: auto;
+            text-decoration: none;
         }    
 
         #navbar-brand {
-            font-size: x-large;
+            font-size: 24px;
             color: rgb(247, 249, 250);
         }
 
@@ -56,9 +61,9 @@
         }
 
         .content-wrapper {
-            margin-left: 60px;
-            margin-right: 60px;
-            margin-top: 20px;
+            margin-left: 7%;
+            margin-right: 7%;
+            margin-top: 5%;
         }
 
         .even-row {
@@ -86,8 +91,7 @@
 
         th, td {
             text-align: left;
-            max-width: 400px;
-            height: 40px;
+            height: auto;
             width: 100%;
             white-space: pre-wrap;
             word-wrap: break-word;
@@ -95,12 +99,22 @@
 
         @media screen and (max-width: 770px) {
 
+            .navbar, .btn-logout, h3 {
+                font-size: 1em; 
+                font-weight: 900;
+            }
+
+            #navbar-brand {
+                font-size: 4.5vw;
+                font-weight: 700;
+            }
+
             .nav-item {
                 text-align: right;
             }
 
-            #navbar-brand {
-                font-size: 1.25em;
+            .navbar-toggler {
+                border: none;
             }
 
             .dropdown-menu {
@@ -125,7 +139,7 @@
 
             .nav-link.dropdown-item:hover {
                 color: white;
-                background-color: transparent;
+                background-color: rgb(0, 200, 200);
             }
 
             .dropdown-menu.show {
@@ -134,13 +148,11 @@
 
             .btn-logout {
                 padding-right: 0%;
-                font-weight: 700;
             }
 
-            h3 {
-                font-size: 1.2em;
-                font-weight: 900;
-            }    
+            table {
+                font-size: 1.8vw;
+            }
         }
 
     </style>
@@ -157,7 +169,7 @@
         <ul class="navbar-nav ml-auto">
         <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Installations
+                Installations
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
             {{#installations}}
@@ -166,8 +178,8 @@
             </div>
         </li>
         <li class="nav-item">
-            <button class="btn btn-link btn-outline btn-logout">
-                <a href="/logout">Log Out</a>
+            <button class="btn btn-logout">
+                <a href="/logout" class="text-decoration-none">Log Out</a>
             </button>
         </li>
         </ul>
@@ -175,19 +187,21 @@
     </nav>
     <div class="content-area">
         <div class="content-wrapper">
-            <br><br>
             <h3>{{currentInstallationName}}</h3>
-            <br><br>
-            <table>
+            <div class="table-responsive">
+            <table class="table table-striped table-sm">
+            <thead>
                 <tr class="table-header">
-                    <th>Unit</th>
-                    <th>Presses</th>
-                    <th>State</th>
-                    <th>Category</th>
-                    <th>Notes</th>
-                    <th>Started At</th>
-                    <th>Updated At</th>
+                    <th scope="col">Unit</th>
+                    <th scope="col">Presses</th>
+                    <th scope="col">State</th>
+                    <th scope="col">Category</th>
+                    <th scope="col">Notes</th>
+                    <th scope="col">Started At</th>
+                    <th scope="col">Updated At</th>
                 </tr>
+            </thead>
+            <tbody>
                 {{#recentSessions}}
                 <tr class="table-data {{class}}">
                     <td>{{unit}}</td>
@@ -199,7 +213,9 @@
                     <td>{{updatedAt}}</td>
                 </tr>
                 {{/recentSessions}}
+            </tbody>
             </table>
+            </div>
         </div>
     </div>
     <script>

--- a/server/login.html
+++ b/server/login.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>Brave Button Dashboard</title>
+        <title>Brave Chatbot Dashboard: Login</title>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     </head>
     <body class="container">

--- a/server/login.html
+++ b/server/login.html
@@ -10,17 +10,17 @@
 
         <div class="container row">
             <div class="jumbotron col-md-5">
-                <form class='form-horizontal'>
+                <form class="form-horizontal" action="login" method="post">
                     <div class="form-group row row-no-gutters">
                         <label for="username" class="control-label">Username:</label>
                         <div>
-                            <input type="text" class="form-control" id="username">
+                            <input type="text" class="form-control" name="username" id="username">
                         </div>
                     </div>
                     <div class="form-group row row-no-gutters">
                         <label for="password" class="control-label">Password:</label>
                         <div>
-                            <input type="password" class="form-control" id="password">
+                            <input type="password" class="form-control" name="password" id="password">
                         </div>
                     </div>
                     <div class="form-group row row-no-gutters">

--- a/server/login.html
+++ b/server/login.html
@@ -8,18 +8,6 @@
             <h1>Welcome to the Brave Button Pilot monitoring system. Please provide your credentials to proceed.</h1>
         </div>
 
-        <nav class="navbar navbar-default">
-            <div class="container-fluid">
-                <!-- Collect the nav links, forms, and other content for toggling -->
-                <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-                    <ul class="nav navbar-nav">
-                        <li><a href="/login">Log In</a></li>
-                        <li><a href="/logout">Log Out</a></li>
-                    </ul>
-                </div><!-- /.navbar-collapse -->
-            </div><!-- /.container-fluid -->
-        </nav>
-
         <div class="container row">
             <div class="jumbotron col-sm-4 pull-center">
                 <form action="/login" method="post">

--- a/server/login.html
+++ b/server/login.html
@@ -9,20 +9,24 @@
         </div>
 
         <div class="container row">
-            <div class="jumbotron col-sm-4 pull-center">
-                <form action="/login" method="post">
-                    <div>
-                        <label>Username:</label>
-                        <input type="text" name="username"/>
+            <div class="jumbotron col-md-5">
+                <form class='form-horizontal'>
+                    <div class="form-group row row-no-gutters">
+                        <label for="username" class="control-label">Username:</label>
+                        <div>
+                            <input type="text" class="form-control" id="username">
+                        </div>
                     </div>
-                    <div>
-                        <label>Password:</label>
-                        <input type="password" name="password"/>
+                    <div class="form-group row row-no-gutters">
+                        <label for="password" class="control-label">Password:</label>
+                        <div>
+                            <input type="password" class="form-control" id="password">
+                        </div>
                     </div>
-                    <div>
+                    <div class="form-group row row-no-gutters">
                         <input class="btn btn-primary" type="submit" value="Log In"/>
                     </div>
-                </form>                  
+                </form>
             </div>          
         </div>
     </body>

--- a/server/login.html
+++ b/server/login.html
@@ -2,6 +2,28 @@
     <head>
         <title>Brave Chatbot Dashboard: Login</title>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+
+        <style>
+
+            body {
+                width: 90%;
+            }
+            
+            input {
+                max-width: 60%;
+            }
+
+            .jumbotron {
+                max-width: 80%;
+            }   
+
+            @media screen and (max-width: 770px) {
+                form {
+                    padding-left: 5%
+                }
+            }
+
+        </style>
     </head>
     <body class="container">
         <div class="page-header">


### PR DESCRIPTION
- Put list of installations into dropdown in nav bar
- Updated page to be responsive for ease of use on mobile/at smaller resolutions (mobile is zoomable but best in landscape)
- Removed unused nav bar from login.html, added some additional styling
- Added log out button to nav bar as route existed but had nothing directing to it
- Updated page titles to match dashboard nav (Brave Chatbot Dashboard), may want to change this if it will be called buttons in the future which I think is the case? But went with what the dashboard itself said for consistency

Note: changes are currently up on chatbot-dev if people are wanting to see them/ask for style revisions without much effort involved :) 
