### PR TITLE
Add API key logging to `/flic_button_press` endpoint (CU-gwxnde)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
         - PGPORT=5433
         - REMINDER_TIMEOUT_MS_TEST=1000
         - FALLBACK_TIMEOUT_MS_TEST=2000
-
+        - FLIC_BUTTON_PRESS_API_KEY_TEST=testFlicApiKey
 
       # setup database
       before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ the code was deployed.
 ## [Unreleased]
 ### Added
 - Added is_active field to conditionally display only active installations in dashboard (CU-fwpya5).
+- Log API key validity for `/flic_button_press` (CU-gwxnde).
 
 ### Fixed
 - All installations now displayed in dropdown on dashboard, and page is responsive (CU-fmudrh).

--- a/server/.env.example
+++ b/server/.env.example
@@ -59,3 +59,7 @@ PG_HOST_TEST=examplehost
 # Port for accessing remote database host
 PG_PORT=12345
 PG_PORT_TEST=12345
+
+# Incoming API key used by Flic Buttons (we made this up, value can be found in 1password)
+FLIC_BUTTON_PRESS_API_KEY=testFlicApiKey
+FLIC_BUTTON_PRESS_API_KEY_TEST=testFlicApiKey

--- a/server/server.js
+++ b/server/server.js
@@ -221,10 +221,21 @@ app.post('/flic_button_press', Validator.header(['button-serial-number']).exists
         if(validationErrors.isEmpty()){
             const serialNumber = req.get('button-serial-number')
             const batteryLevel = req.get('button-battery-level')
+            const buttonName = req.get('button-name')
+            const apiKey = req.query.apikey
+
+            // Log the vaiditiy of the API key
+            // TODO (CU-gwxnde) Replace this with a 401 unauthorized if invalid
+            if (apiKey !== helpers.getEnvVar('FLIC_BUTTON_PRESS_API_KEY')) {
+                helpers.log(`INVALID api key from '${buttonName}' (${serialNumber})`)
+            }
+            else {
+                helpers.log(`VALID api key from '${buttonName}' (${serialNumber})`)
+            }
 
             let button = await db.getButtonWithSerialNumber(serialNumber)
             if(button === null) {
-                helpers.log(`Bad request: Serial Number is not registered. Serial Number is ${serialNumber}`)
+                helpers.log(`Bad request: Serial Number is not registered. Serial Number for '${buttonName}' is ${serialNumber}`)
                 res.status(400).send();
             }
             else {


### PR DESCRIPTION
- To be used to verify that all the Buttons are correctly configured
  with the right API key before enforcing this authorization