### PR TITLE
Validate Twilio requests (CU-dgmfbv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ was committed to the `master` branch. This is not necessarily the date that
 the code was deployed.
 
 ## [Unreleased]
+### Changed
+- Update to use brave-alert-lib v2.1.0 which includes Twilio validation (CU-dgmfbv).
 
 ## [3.0.0] - 2020-12-07
 ### Added

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -411,8 +411,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#dda5178759ca757c0aed487055475a67d05025fe",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v2.0.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#f617ccbc222e38f28e615f9450837109fa5786de",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v2.1.0",
       "requires": {
         "chalk": "^4.1.0",
         "dotenv": "^7.0.0",
@@ -936,9 +936,9 @@
       }
     },
     "dayjs": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.6.tgz",
-      "integrity": "sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw=="
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.7.tgz",
+      "integrity": "sha512-IC877KBdMhBrCfBfJXHQlo0G8keZ0Opy7YIIq5QKtUbCuHMzim8S4PyiVK4YmihI3iOF9lhfUBW4AQWHTR5WHA=="
     },
     "debug": {
       "version": "2.6.9",
@@ -1978,9 +1978,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -3188,9 +3188,9 @@
       "dev": true
     },
     "twilio": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.52.0.tgz",
-      "integrity": "sha512-G/2J4iva5T8080Mei3e24bCBxAemVe766iYQP+OonAzP7EUx9sv/hnNoNsM5u1vKkqKn7ER2uJ+mRI6bJrdEMA==",
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.54.0.tgz",
+      "integrity": "sha512-jAM23itfMvpqgm033V55/iOq9vEXe3x5NwOSTFE9ekQWuula06D0iV4Fpj6JyflSbiHfvQqqn/+yPm4yitKHxQ==",
       "requires": {
         "axios": "^0.19.2",
         "dayjs": "^1.8.29",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.18.3",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v2.0.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v2.1.0",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "express-session": "^1.15.6",

--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,8 @@
     "mocha": "^5.2.0",
     "sinon": "^9.0.3",
     "sinon-chai": "^3.5.0",
-    "nyc": "^14.1.1"
+    "nyc": "^14.1.1",
+    "twilio": "^3.49.3"
   },
   "scripts": {
     "lint": "eslint . -c ../.eslintrc.json",

--- a/server/test/serverTest.js
+++ b/server/test/serverTest.js
@@ -4,7 +4,7 @@ const expect = chai.expect
 const { after, afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 const sinonChai = require("sinon-chai")
-const { ALERT_STATE, helpers } = require('brave-alert-lib')
+const { ALERT_STATE, helpers, Twilio } = require('brave-alert-lib')
 
 chai.use(chaiHttp)
 chai.use(sinonChai)
@@ -414,6 +414,8 @@ describe('Chatbot server', () => {
 
             sinon.spy(imports.braveAlerter, 'startAlertSession')
             sinon.spy(imports.braveAlerter, 'sendSingleAlert')
+
+            sinon.stub(Twilio, 'isValidTwilioRequest').returns(true)
         });
 
         afterEach(async function() {
@@ -424,6 +426,9 @@ describe('Chatbot server', () => {
             await db.clearButtons()
             await db.clearInstallations()
             helpers.log('\n')
+
+            Twilio.isValidTwilioRequest.restore()
+
         });
 
         after(async function() {

--- a/server/test/serverTest.js
+++ b/server/test/serverTest.js
@@ -4,7 +4,8 @@ const expect = chai.expect
 const { after, afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 const sinonChai = require("sinon-chai")
-const { ALERT_STATE, helpers, Twilio } = require('brave-alert-lib')
+const twilio = require('twilio')
+const { ALERT_STATE, helpers } = require('brave-alert-lib')
 
 chai.use(chaiHttp)
 chai.use(sinonChai)
@@ -415,20 +416,19 @@ describe('Chatbot server', () => {
             sinon.spy(imports.braveAlerter, 'startAlertSession')
             sinon.spy(imports.braveAlerter, 'sendSingleAlert')
 
-            sinon.stub(Twilio, 'isValidTwilioRequest').returns(true)
+            sinon.stub(twilio, 'validateExpressRequest').returns(true)
         });
 
         afterEach(async function() {
             imports.braveAlerter.sendSingleAlert.restore()
             imports.braveAlerter.startAlertSession.restore()
 
+            twilio.validateExpressRequest.restore()
+
             await db.clearSessions()
             await db.clearButtons()
             await db.clearInstallations()
             helpers.log('\n')
-
-            Twilio.isValidTwilioRequest.restore()
-
         });
 
         after(async function() {


### PR DESCRIPTION
- Add Twilio back as a dev dependency
- Mock Twilio's `validateExpressRequest` function to satisfy `brave-alert-lib`'s `handleTwilioRequest` in `serverTest.js`