### PR TITLE
Handle all promise rejections in async functions (CU-brqahw)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ the code was deployed.
 ### Added
 - Added wifi link quality monitoring to Brave Hub in heartbeat.py (CU-fmy630).
 
+### Fixed
+- Handle all promise rejections in async function (CU-brqahw).
+
 ### Security
 - Update Twilio references in order to get the latest version of axios (CU-j6yuzk).
 

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -50,6 +50,11 @@ module.exports.commitTransaction = async function(client) {
     client.release()
 }
 
+module.exports.rollbackTransaction = async function(client) {
+    await client.query("ROLLBACK")
+    client.release()
+}
+
 module.exports.getUnrespondedSessionWithButtonId = async function(buttonId, client) {
     let transactionMode = (typeof client !== 'undefined')
     if(!transactionMode) {

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -101,7 +101,7 @@ module.exports.getUnrespondedSessionWithButtonId = async function(buttonId, clie
         const values = [buttonId, ALERT_STATE.WAITING_FOR_CATEGORY, ALERT_STATE.WAITING_FOR_DETAILS, ALERT_STATE.COMPLETED]
         const { rows } = await client.query(query, values)
 
-        if(rows.length > 0) {        
+        if(rows.length > 0) {     
             return createSessionFromRow(rows[0])
         }
     }
@@ -324,6 +324,14 @@ module.exports.saveSession = async function(session, client) {
     }
 }
 
+module.exports.getPool = function() {
+    if(!helpers.isTestEnvironment()) {
+        helpers.log('warning - tried to get pool outside the test environment')
+        return
+    }
+
+    return pool
+}
 
 module.exports.clearSessions = async function(client) {
     if(!helpers.isTestEnvironment()) {

--- a/server/test/BraveAlerterConfiguratorTest.js
+++ b/server/test/BraveAlerterConfiguratorTest.js
@@ -5,30 +5,12 @@ const { afterEach, before, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 const sinonChai = require("sinon-chai")
 const db = require('../db/db.js')
-const SessionState = require('../SessionState.js')
+const { createTestSessionState } = require('./testingHelpers.js')
 
 const BraveAlerterConfigurator = require('./../BraveAlerterConfigurator.js')
 
 // Configure Chai
 chai.use(sinonChai)
-
-function createTestSessionState() {
-    return new SessionState(
-        'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc',
-        'fakeInstallationId',
-        'fakeButtonId',
-        'fakeUnit',
-        'fakePhone',
-        'fakeState',
-        'fakeNumPresses',
-        'fakeCreatedAt',
-        'fakeUpdatedAt',
-        '1',
-        'fakeNotes',
-        'fakeFallbackTwilioState',
-        null
-    )
-}
 
 describe('BraveAlerterConfigurator', () => {
     describe('createBraveAlerter', () => {

--- a/server/test/dbTest.js
+++ b/server/test/dbTest.js
@@ -1,0 +1,237 @@
+const chai = require('chai')
+const expect = chai.expect
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require("sinon-chai")
+const { helpers } = require('brave-alert-lib')
+
+chai.use(sinonChai)
+
+const db = require('../db/db.js')
+const { createTestSessionState } = require('./testingHelpers')
+
+describe('DB', () => {
+    describe('getUnrespondedSessionWithButtonId', () => {
+        describe('when not given a client', () => {
+            describe('if an error is thrown while trying to get a DB client from the pool', () => {
+                beforeEach(() => {
+                    sinon.stub(helpers, 'log')
+                    this.pool = db.getPool()
+                    sinon.stub(this.pool, 'connect').rejects
+                })
+
+                afterEach(() => {
+                    helpers.log.restore()
+                    this.pool.connect.restore()
+                })
+
+                it('should log the error', async () => {
+                    await db.getUnrespondedSessionWithButtonId('fakeButtonId')
+                    expect(helpers.log).to.be.calledWithMatch('Error running the getUnrespondedSessionWithButtonId query:')
+                })
+
+                it('should log that it could not release the client', async () => {
+                    await db.getUnrespondedSessionWithButtonId('fakeButtonId')
+                    expect(helpers.log).to.be.calledWithMatch('getUnrespondedSessionWithButtonId: Error releasing client:')
+                })
+
+                it('should not do any other logging', async () => {
+                    await db.getUnrespondedSessionWithButtonId('fakeButtonId')
+                    expect(helpers.log).to.be.calledTwice
+                })
+
+                it('should return null', async () => {
+                    const returnValue = await db.getUnrespondedSessionWithButtonId('fakeButtonId')
+                    expect(returnValue).to.be.null
+                })
+            })
+
+            describe('if an error is thrown during a database query', () => {
+                beforeEach(() => {
+                    sinon.stub(helpers, 'log')
+                    this.client = {
+                        query: sinon.stub().rejects,
+                        release: sinon.stub(),
+                    }
+                    this.pool = db.getPool()
+                    sinon.stub(this.pool, 'connect').returns(this.client)
+                })
+
+                afterEach(() => {
+                    helpers.log.restore()
+                    this.pool.connect.restore()
+                })
+
+                it('should log the error', async () => {
+                    await db.getUnrespondedSessionWithButtonId('fakeButtonId')
+                    expect(helpers.log).to.be.calledWithMatch('Error running the getUnrespondedSessionWithButtonId query:')
+                })
+
+                it('should not do any other logging', async () => {
+                    await db.getUnrespondedSessionWithButtonId('fakeButtonId')
+                    expect(helpers.log).to.be.calledOnce
+                })
+
+                it('should release the client', async () => {
+                    await db.getUnrespondedSessionWithButtonId('fakeButtonId')
+                    expect(this.client.release).to.be.called
+                })
+
+                it('should return null', async () => {
+                    const returnValue = await db.getUnrespondedSessionWithButtonId('fakeButtonId')
+                    expect(returnValue).to.be.null
+                })
+            })
+
+            describe('if there is one unresponded session with the given buttonId', () => {
+                beforeEach(() => {
+                    sinon.stub(helpers, 'log')
+                    this.client = {
+                        query: sinon.stub().resolves({
+                            rows: [
+                                {
+                                    id: 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc',
+                                    installation_id: 'fakeInstallationId',
+                                    button_id: 'fakeButtonId',
+                                    unit: 'fakeUnit',
+                                    phone_number: 'fakePhone',
+                                    state: 'fakeState',
+                                    num_presses: 'fakeNumPresses',
+                                    created_at: 'fakeCreatedAt',
+                                    updated_at: 'fakeUpdatedAt',
+                                    incident_type: '1',
+                                    notes: 'fakeNotes',
+                                    fallback_alert_twilio_status: 'fakeFallbackTwilioState',
+                                    button_battery_level: null,
+                                }
+                            ]
+                        }),
+                        release: sinon.stub(),
+                    }
+                    this.pool = db.getPool()
+                    sinon.stub(this.pool, 'connect').returns(this.client)
+                })
+
+                afterEach(() => {
+                    helpers.log.restore()
+                    this.pool.connect.restore()
+                })
+                
+                it('should not log anything', async () => {
+                    await db.getUnrespondedSessionWithButtonId('fakeButtonId')
+                    expect(helpers.log).not.to.be.called
+                })
+                
+                it('should release the client', async () => {
+                    await db.getUnrespondedSessionWithButtonId('fakeButtonId')
+                    expect(this.client.release).to.have.been.calledOnce
+                })
+
+                it('should return a SessionState with the values returned from the query', async () => {
+                    const expected = createTestSessionState()
+                    const actual = await db.getUnrespondedSessionWithButtonId('fakeButtonId')
+
+                    expect(actual).to.eql(expected)
+                })
+            })
+        })
+    })
+
+    describe('when given a client', () => {
+        describe('if an error is thrown during a database query', () => {
+            beforeEach(() => {
+                sinon.stub(helpers, 'log')
+
+                this.pool = db.getPool()
+                sinon.stub(this.pool, 'connect')
+
+                this.client = {
+                    query: sinon.stub().rejects,
+                    release: sinon.stub(),
+                }
+            })
+
+            afterEach(() => {
+                helpers.log.restore()
+                this.pool.connect.restore()
+            })
+
+            it('should log the error', async () => {
+                await db.getUnrespondedSessionWithButtonId('fakeButtonId', this.client)
+                expect(helpers.log).to.be.calledWithMatch('Error running the getUnrespondedSessionWithButtonId query:')
+            })
+
+            it('should not do any other logging', async () => {
+                await db.getUnrespondedSessionWithButtonId('fakeButtonId', this.client)
+                expect(helpers.log).to.be.calledOnce
+            })
+
+            it('should not try to get a client from the pool', async () => {
+                await db.getUnrespondedSessionWithButtonId('fakeButtonId', this.client)
+                expect(this.pool.connect).not.to.have.been.called
+            })
+
+            it('should not try to release the client', async () => {
+                await db.getUnrespondedSessionWithButtonId('fakeButtonId', this.client)
+                expect(this.client.release).not.to.have.been.called
+            })
+
+            it('should return null', async () => {
+                const returnValue = await db.getUnrespondedSessionWithButtonId('fakeButtonId', this.client)
+                expect(returnValue).to.be.null
+            })
+        })
+
+        describe('if there is one unresponded session with the given buttonId', () => {
+            beforeEach(() => {
+                sinon.stub(helpers, 'log')
+                this.client = {
+                    query: sinon.stub().resolves({
+                        rows: [
+                            {
+                                id: 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc',
+                                installation_id: 'fakeInstallationId',
+                                button_id: 'fakeButtonId',
+                                unit: 'fakeUnit',
+                                phone_number: 'fakePhone',
+                                state: 'fakeState',
+                                num_presses: 'fakeNumPresses',
+                                created_at: 'fakeCreatedAt',
+                                updated_at: 'fakeUpdatedAt',
+                                incident_type: '1',
+                                notes: 'fakeNotes',
+                                fallback_alert_twilio_status: 'fakeFallbackTwilioState',
+                                button_battery_level: null,
+                            }
+                        ]
+                    }),
+                    release: sinon.stub(),
+                }
+                this.pool = db.getPool()
+                sinon.stub(this.pool, 'connect')
+            })
+
+            afterEach(() => {
+                helpers.log.restore()
+                this.pool.connect.restore()
+            })
+            
+            it('should not log anything', async () => {
+                await db.getUnrespondedSessionWithButtonId('fakeButtonId', this.client)
+                expect(helpers.log).not.to.be.called
+            })
+
+            it('should not try to release the client', async () => {
+                await db.getUnrespondedSessionWithButtonId('fakeButtonId', this.client)
+                expect(this.client.release).not.to.have.been.calledOnce
+            })
+
+            it('should return a SessionState with the values returned from the query', async () => {
+                const expected = createTestSessionState()
+                const actual = await db.getUnrespondedSessionWithButtonId('fakeButtonId', this.client)
+
+                expect(actual).to.eql(expected)
+            })
+        })
+    })
+})

--- a/server/test/testingHelpers.js
+++ b/server/test/testingHelpers.js
@@ -1,0 +1,23 @@
+const SessionState = require('../SessionState.js')
+
+function createTestSessionState() {
+    return new SessionState(
+        'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc',
+        'fakeInstallationId',
+        'fakeButtonId',
+        'fakeUnit',
+        'fakePhone',
+        'fakeState',
+        'fakeNumPresses',
+        'fakeCreatedAt',
+        'fakeUpdatedAt',
+        '1',
+        'fakeNotes',
+        'fakeFallbackTwilioState',
+        null
+    )
+}
+
+module.exports = {
+    createTestSessionState,
+}


### PR DESCRIPTION
- Added try/catches to all the async functions. This should handle all our promise rejections.
   - At the moment, the `catch` blocks generally don't do anything interesting. They just log the error. This follows what @mariocimet did in the BraveSensor-Server codebase. This would probably be a good place to introduce Sentry into our code. Then we can be notified when these happen in production.
- Added rollbacks in the `catch` blocks of functions that use DB transactions. This might help remove the deadlock problems that we've been seeing when running the tests.

I tried writing some automated tests for this, but as soon as I'd try to catch the promise rejection, then it would not longer be unhandled and hence the error would go away. So I just tried a few things out manually to see if the warning was there or not when I expected it to be.

As of Jan 19, this is deployed on `chatbot-dev`. I've tried out all the endpoints and they still seem to work as I expected.