### PR TITLE
Use `npm ci` instead of `npm install` for Travis and deployment scripts (CU-jcwffp)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       # install dependencies
       install:
         - cd server
-        - npm install
+        - npm ci
 
       # install database
       addons:
@@ -78,7 +78,7 @@ matrix:
       # install dependencies
       install:
         - cd pairing-tool
-        - npm install
+        - npm ci
 
       # run linter
       script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ the code was deployed.
 ### Added
 - Implement linting on Buttons repo (CU-eprhhn).
 
-## [3.2.0]
+## Changed
+- Use `npm ci` instead of `npm install` in Travis and the deployment scripts (CU-jcwffp).
+
+## [3.2.0] - 2020-02-01
 ### Added
 - Added wifi link quality monitoring to Brave Hub in heartbeat.py (CU-fmy630).
 

--- a/pairing-tool/setup_pi.sh
+++ b/pairing-tool/setup_pi.sh
@@ -17,5 +17,5 @@ else
   PATH="$PATH"
 
   # install dependencies
-  su pi -c 'npm install'
+  su pi -c 'npm ci'
 fi

--- a/server/setup_server.sh
+++ b/server/setup_server.sh
@@ -44,7 +44,7 @@ else
     apt install -y nodejs npm certbot postgresql postgresql-contrib
     npm install -g pm2 n
     n 12.18.3         # keep this in sync with .nvmrc for Travis
-    npm install
+    npm ci
 
     echo "Please enter in order the name and responder phone number and fallback phone number for the first installation (separated by a space):" 
     echo "NOTE that this will have no effect if this script has already been run"


### PR DESCRIPTION
This means that they will always use the exact versions specified in the package-lock.json file, thus ensuring more consistent builds (see NPM docs: https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable)

Note that the Task only specifies to do this for `/server`. I also made the change for the `/pi` directory. I think we had talked about this before and came to the conclusion to only do `/server`, but now I can't remember why. Do you remember @schwarrrtz or @mariocimet ?

I also added the missing deployment date from the CHANGELOG that I forgot.