### PR TITLE
Use helpers.logError instead of console.error (CU-jcuw85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the code was deployed.
 
 ## Changed
 - Use `npm ci` instead of `npm install` in Travis and the deployment scripts (CU-jcwffp).
+- Added timestamps to error logs (CU-jcuw85).
 
 ## [3.2.0] - 2020-02-01
 ### Added

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -15,8 +15,7 @@ const pool = new Pool({
 })
 
 pool.on('error', err => {
-  // eslint-disable-next-line no-console
-  console.error('unexpected database error:', err)
+  helpers.logError(`unexpected database error: ${JSON.stringify(err)}`)
 })
 
 types.setTypeParser(types.builtins.NUMERIC, value => parseFloat(value))

--- a/server/ecosystem.config.js
+++ b/server/ecosystem.config.js
@@ -3,6 +3,7 @@ module.exports = {
     {
       name: 'BraveServer',
       script: './server.js',
+      log_date_format: 'YYYY-MM-DD HH:mm:ss.SSS',
       autorestart: true,
       max_memory_restart: '200M',
       env: {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -635,13 +635,13 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#4c0af667a2453eed32b1143c2bf66a5746dd4ff6",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v2.2.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#c2817bb644bea3d741b024bac41a7050682ae8cf",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v2.4.0",
       "requires": {
+        "body-parser": "^1.19.0",
         "chalk": "^4.1.0",
         "dotenv": "^7.0.0",
         "express": "^4.17.1",
-        "moment-timezone": "^0.5.31",
         "twilio": "^3.54.2"
       }
     },

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.18.3",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v2.2.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v2.4.0",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "express-session": "^1.15.6",


### PR DESCRIPTION
- This will add the timestamp to error output in production