### PR TITLE
Add ability to send multiple fallback messages (CU-pv8hd5, CU-p107rc, CU-307j4h)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -9,11 +10,14 @@ was committed to the `master` branch. This is not necessarily the date that
 the code was deployed.
 
 ## [Unreleased]
+
 ### Added
 - Send urgent message on button press if it has been >= 2 minutes since last session update, regardless of if it is a multiple of 5 presses (CU-j6y98q).
 - Start new session if "current" session is waiting for reply and it has been >= 2 hours since last update (CU-j6yfct).
+- Ability to have multiple fallback phone numbers (CU-pv8hd5).
 
 ## [3.4.0] - 2020-03-29
+
 ### Added
 - Add CSV button to dashboard (CU-c8htxp).
 
@@ -21,57 +25,75 @@ the code was deployed.
 - Do not serve static files from server (CU-mz0td3).
 
 ## [3.3.0] - 2020-03-08
+
 ### Added
+
 - Implement linting on Buttons repo (CU-eprhhn).
 
 ## Changed
+
 - Use `npm ci` instead of `npm install` in Travis and the deployment scripts (CU-jcwffp).
 - Added timestamps to error logs (CU-jcuw85).
 
-
 ## [3.2.0] - 2020-02-01
+
 ### Added
+
 - Added wifi link quality monitoring to Brave Hub in heartbeat.py (CU-fmy630).
 
 ### Fixed
+
 - Handle all promise rejections in async function (CU-brqahw).
 
 ### Security
+
 - Update Twilio references in order to get the latest version of axios (CU-j6yuzk).
 
 ## [3.1.0] - 2021-01-04
+
 ### Added
+
 - Added landing page for chatbot dashboard so page will load when there are no installations selected or present (CU-gurbtf).
 - Added Battery Level to sessions table and dashboard display (CU-fgyh0g).
 
 ### Changed
+
 - Update to use brave-alert-lib v2.1.0 which includes Twilio validation (CU-dgmfbv).
 
 ## [3.0.0] - 2020-12-07
+
 ### Added
+
 - `pi_setup.sh` and the associated template files now support network over PoE (CU-gcuhbk).
 - Added is_active field to conditionally display only active installations in dashboard (CU-fwpya5).
 - Log API key validity for `/flic_button_press` (CU-gwxnde).
 
 ### Changed
+
 - Use the Brave Alert Library for the text message flow (CU-bar0fm).
 
 ### Fixed
+
 - All installations now displayed in dropdown on dashboard, and page is responsive (CU-fmudrh).
 - Built in documentation in `add_buttons.csv.example` and `add_installation.sh` (CU-f8w261).
 
 ## [2.1.0] - 2020-11-12
+
 ### Changed
+
 - The time between the initial text message and the reminder is now 2 minutes (CU-eanm0j).
 - Allow calls to `POST /flic_button_press` without the `button-battery-level` header (CU-f0w9qm).
 
 ### Fixed
+
 - Double click handling (CU-f0w9qm).
 - Button press counting for POST requests to '/' to workaround a MS Flow bug (CU-f0w9qm).
 - Sent urgent text messages at the same frequency whether from '/' or '/flic_button_press' (CU-f0w9qm).
 
 ## [2.0.0] - 2020-10-29
+
 ### Added
+
 - Deployment instructions in the README file (CU-d8rfw8).
 - Unhide endpoint for the heartbeat (CU-bgke33).
 - Heartbeat text message alert when the Last Seen (Ping) value is above a threshold (CU-crut3u).
@@ -81,28 +103,35 @@ the code was deployed.
 - Shell script for adding new hubs to database.
 
 ### Changed
+
 - Merged heartbeat and chatbot functionality into a single application (CU-bgke33).
 - Heartbeat text message alert now further details what triggered the alert (CU-crut3u).
 - Increased alert message threshold for Heartbeat and Flic (Darkstat) (CU-70bdx5).
 - In setup_pi.yaml, Ansible now updates the comment on the remote access authorized_keys file.
 
 ## [1.6.0] - 2020-10-05
+
 ### Added
+
 - Column definitions to the Heartbeat Dashboard (CU-bgjqh5).
 - Ansible playbooks for RPi setup and deployment of updates (CU-5jcgu2 and CU-5jcgvh).
 
 ### Changed
+
 - db.js now loads different environment variables depending on NODE_ENV test flag (CU-byp1m3).
 - Increased wait time in fallback message test to address race condition and reduce test flakiness (CU-3j6jj7).
 - setup_pi.sh only echoes SSH public key and blocks if the SSH key does not exist
 - setup_pi.sh no longer reboots the RPi
 
 ### Security
+
 - Upgrade handlebars (CU-c6rgqh).
 - Upgrade yargs-parser (CU-c6rgqh).
 
 ## [1.5.0] - 2020-09-04
+
 ### Added
+
 - Changelog (CU-5wd4g9).
 - Environment variables to Travis config (CU-b4m32r).
 - More logging to the Raspberry Pi (CU-behg93).
@@ -111,42 +140,56 @@ the code was deployed.
 - `POST /unmute_system` API endpoint for the Heartbeat server (CU-baj2pv).
 
 ### Changed
+
 - "From" phone number used to send messages to the fallback phone is specified in `.env` (CU-6ed85y).
 - Local version of database setup script for use in TravisCI and local dev
 - db.js file now creates pool with remote database parameters
 - Heartbeat Dashboard displays whether a hub is muted or not (CU-baj2pv).
 
 ## [1.4.3] - 2020-08-18
+
 ### Added
+
 - Installation instructions to the README.
 
 ### Changed
+
 - Replace cron cert renewal with simple weekly restart.
 - Update node to v12.18.3 for heartbeat and chatbot.
 - Installation script improvements.
 
 ### Fixed
+
 - Better fix for darkstat parsing edge case.
 
 ### Security
+
 - Upgrade lodash and minimist.
 
 ## [1.4.2] - 2020-08-06
+
 ### Changed
+
 - Specify Postgres and Node versions for Travis.
 
 ### Fixed
+
 - Darkstat parsing edge case.
 
 ## [1.4.1] - 2020-07-24
+
 ### Added
+
 - Ability to mute heartbeat alerts.
 
 ### Security
+
 - Upgrade acorn.
 
 ## [1.4.0] - 2020-04-06
+
 ### Added
+
 - ESLint for chatbot.
 - Ability to hide systems on heartbeat dashboard.
 - Script to add buttons in a batch.
@@ -155,44 +198,57 @@ the code was deployed.
 - Installation-specific incident categories.
 
 ### Fixed
+
 - Malformed text in chatbot category response.
 - Wifi on Raspbian Buster.
 
 ### Security
+
 - Patched DoS vulnerability.
 
 ## [1.3.0] - 2019-11-15
+
 ### Added
+
 - All BraveChatbot code moved from its own repo to the `chatbot` directory.
 - Istanbul.js for code coverage.
 - Log rotation.
 - Alert flag to Sessions table.
 
 ### Changed
+
 - Installation script takes `installationName` as a parameter.
 - Travis runs both chatbot and pi tests.
 - Made setup scripts executable.
 
 ### Fixed
+
 - Bug in chatbot cert renewal.
 
 ### Security
+
 - `npm audit` fixes.
 
 ## [1.2.1-chatbot] - 2019-08-13
+
 ### Fixed
+
 - Bug in `sendStaffAlertForSession`.
 
 ### Security
+
 - Update Twilio library.
 
 ## [1.2-chatbot] - 2019-07-16
+
 ### Added
+
 - Everything else chatbot-related.
 - New Dashboard that automatically refreshes itself.
 - PostgreSQL migration structure.
 
 ### Changed
+
 - Use PostgreSQL instead of NeDB.
 - Use async/await for DB handling and tests.
 - Improve server tests.
@@ -201,31 +257,41 @@ the code was deployed.
 - Increase life of login cookie.
 
 ### Fixed
+
 - Concurrency issue.
 
 ### Removed
+
 - Global state.
 - Old Dashboard.
 
 ## [1.0-chatbot] - 2018-12-19
+
 ### Added
+
 - Initial chatbot.
 
 ## [1.2-pi-heartbeat] - 2019-07-16
+
 ### Added
+
 - Travis CI to run automated tests.
 - Heartbeat code to regularly ping the Flic Hub and send resulting data to the server.
 - Wifi connectivity for the Raspberry Pi.
 
 ### Changed
+
 - Specify separate test requirements for pip.
 - pi install script uses config file instead of interactive input.
 
 ## [1.0-pi-heartbeat] - 2019-01-11
+
 ### Added
+
 - Initial pi.
 
-[Unreleased]: https://github.com/bravetechnologycoop/BraveButtons/compare/v3.3.0...HEAD
+[unreleased]: https://github.com/bravetechnologycoop/BraveButtons/compare/v3.4.0...HEAD
+[3.4.0]: https://github.com/bravetechnologycoop/BraveButtons/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/bravetechnologycoop/BraveButtons/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/bravetechnologycoop/BraveButtons/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/bravetechnologycoop/BraveButtons/compare/v3.0.0...v3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ the code was deployed.
 - Start new session if "current" session is waiting for reply and it has been >= 2 hours since last update (CU-j6yfct).
 - Ability to have multiple fallback phone numbers (CU-pv8hd5).
 
+### Changed
+
+- Renamed `registry` table to `buttons` (CU-p107rc).
+
 ## [3.4.0] - 2020-03-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -156,6 +156,24 @@ making a new tag during step 2. This is essentially redeploying an older version
 
 1. open the chatbot and heartbeat dashboards and confirm that everything appears to be working normally
 
+# How to check the logs
+
+- To view the logs on the server, first SSH into the server.
+
+    - Run `sudo pm2 logs` to follow a tail of both console and error logs
+
+    - Run `less ~/.pm2/logs/BraveServer-out.log` to view the console logs or `less ~/.pm2/logs/BraveServer-error.log` to view the error logs
+
+    - Run `tail -f ~/.pm2/logs/BraveServer-out.log` to follow the tail of the console logs or `tail -f ~/.pm2/logs/BraveServer-error.log` to follow the tail of the error logs
+
+    - Run `zcat ~/.pm2/logs/<filename.log.gz> | less` to view any of the archived logs in `~/.pm2/logs`
+
+- To view the logs on the Raspberry Pi, first SSH into the remote access server and then SSH into the pi
+
+    - Run `tail -f /var/log/brave/heartbeat.log` to follow the tail of the logs
+
+    - Run `less /var/log/brave/<logfilename>` to view any of the logs in `/var/log/brave`
+
 # How to run tests for the raspberry pi code: 
 
 1. install pytest and pytest-cov (run `pip3 install pytest pytest-cov`)
@@ -199,9 +217,22 @@ ORDER BY id;
 
 Reference: https://docs.travis-ci.com/user/environment-variables/#encrypting-environment-variables
 
-1. Download the Travis CLI `brew install travis` or `gem install travis`
+1. Download the Travis CLI `gem install travis`
 
 1. cd to anywhere in this repo
+
+1. temporarily create a personal access token on GitHub https://github.com/settings/tokens with the following permissions:
+
+   - `repo`
+   - `read:packages`
+   - `read:org`
+   - `read:public_key`
+   - `read:repo_hook`
+   - `user`
+   - `read:discussion`
+   - `read:enterprise`
+
+1. login using `travis login --pro --github-token <token from github>`
 
 1. For a given `VAR_NAME` that you want to have value `secret_value`, run
    `travis encrypt --pro VAR_NAME=secret_value`
@@ -209,6 +240,8 @@ Reference: https://docs.travis-ci.com/user/environment-variables/#encrypting-env
    output your encrypted variable
 
 1. Copy the encrypted variable into `.travis.yml`
+
+1. Delete your personal access token from GitHub
 
 # How to run a migration script
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -16,7 +16,7 @@ TWILIO_TOKEN_TEST=def456 # must be from Twilio Test Credentials: https://www.twi
 REMINDER_TIMEOUT_MS=120000
 REMINDER_TIMEOUT_MS_TEST=1000 # should be 1000
 
-# Number of ms after the initial message to send the fallback message
+# Number of ms after the initial message to send the fallback message(s)
 FALLBACK_TIMEOUT_MS=240000
 FALLBACK_TIMEOUT_MS_TEST=2000 # should be 2000
 

--- a/server/Installation.js
+++ b/server/Installation.js
@@ -1,9 +1,9 @@
 class Installation {
-  constructor(id, name, responderPhoneNumber, fallbackPhoneNumber, incidentCategories, isActive, createdAt) {
+  constructor(id, name, responderPhoneNumber, fallbackPhoneNumbers, incidentCategories, isActive, createdAt) {
     this.id = id
     this.name = name
     this.responderPhoneNumber = responderPhoneNumber
-    this.fallbackPhoneNumber = fallbackPhoneNumber
+    this.fallbackPhoneNumbers = fallbackPhoneNumbers
     this.incidentCategories = incidentCategories
     this.isActive = isActive
     this.createdAt = createdAt

--- a/server/db/011-alterfallbackphonenumbertobeanarray.sql
+++ b/server/db/011-alterfallbackphonenumbertobeanarray.sql
@@ -1,0 +1,22 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 11;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        ALTER TABLE installations ALTER fall_back_phone_number TYPE text[] USING array[fall_back_phone_number];
+        ALTER TABLE installations RENAME COLUMN fall_back_phone_number TO fall_back_phone_numbers;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/db/012-renameregistrytobuttons.sql
+++ b/server/db/012-renameregistrytobuttons.sql
@@ -1,0 +1,21 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 12;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        ALTER TABLE registry RENAME TO buttons;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/db/add_buttons_to_installation.sh
+++ b/server/db/add_buttons_to_installation.sh
@@ -10,12 +10,12 @@ if [[ $EUID > 0 ]]; then
     exit 1
 elif [[ ! -n "$3" ]]; then
     echo ""
-    echo "Usage: $0 path_to_.env_file existing_installation_name path_to_registry_csv"
+    echo "Usage: $0 path_to_.env_file existing_installation_name path_to_buttons_csv"
     echo "" 
     echo "Example: $0 ./../.env ExistingInstallation ./add_buttons.csv.example"
     echo ""
-    echo "The registry CSV file"
-    echo "MUST have the header 'button_id,unit,phone_number'"
+    echo "The buttons CSV file"
+    echo "MUST have the header 'button_id,unit,phone_number,button_serial_number'"
     echo "MUST use Unix line endings (LF), or else the phone numbers will have '\r' at the end"
     echo "MUST end with a newline, or else the last button will be silently ignored"
     echo ""
@@ -49,7 +49,7 @@ else
             echo "  Phone Number: $phone_number"
             echo "  Serial Number: $button_serial_number"
 
-        sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -c "INSERT INTO registry (button_id, button_serial_number, unit, phone_number, installation_id) VALUES ('$button_id', '$button_serial_number', '$unit', '$phone_number', '$installation_id');"
+        sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -c "INSERT INTO buttons (button_id, button_serial_number, unit, phone_number, installation_id) VALUES ('$button_id', '$button_serial_number', '$unit', '$phone_number', '$installation_id');"
         fi
     done < $3
 

--- a/server/db/add_installation.sh
+++ b/server/db/add_installation.sh
@@ -10,9 +10,9 @@ if [[ $EUID > 0 ]]; then
     exit 1
 elif [[ ! -n "$5" ]]; then
     echo ""
-    echo "Usage: $0 path_to_.env_file new_installation_name responder_phone_number fallback_phone_number path_to_registry_csv"
+    echo "Usage: $0 path_to_.env_file new_installation_name responder_phone_number fallback_phone_numbers path_to_registry_csv"
     echo "" 
-    echo "Example: $0 ./../.env NewInstallation +16041234567 +17781234567 ./add_buttons.csv.example"
+    echo "Example: $0 ./../.env NewInstallation +16041234567 '{\"+17781234567\",\"+17789876543\"}' ./add_buttons.csv.example"
     echo ""
     echo "The registry CSV file"
     echo "MUST have the header 'button_id,unit,phone_number,button_serial_number'"
@@ -37,7 +37,7 @@ else
     echo "Adding new installation"
     echo "  Name: $2"
     echo "  Responder Phone: $3"
-    echo "  Fallback Phone: $4"
+    echo "  Fallback Phones: $4"
     sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -c "INSERT INTO installations VALUES (DEFAULT, '$2', '$3', '$4');"
 
     installation_id=$(sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -qtAX -c "SELECT id FROM installations WHERE created_at = (SELECT MAX(created_at) FROM installations);")

--- a/server/db/add_installation.sh
+++ b/server/db/add_installation.sh
@@ -10,11 +10,11 @@ if [[ $EUID > 0 ]]; then
     exit 1
 elif [[ ! -n "$5" ]]; then
     echo ""
-    echo "Usage: $0 path_to_.env_file new_installation_name responder_phone_number fallback_phone_numbers path_to_registry_csv"
+    echo "Usage: $0 path_to_.env_file new_installation_name responder_phone_number fallback_phone_numbers path_to_buttons_csv"
     echo "" 
     echo "Example: $0 ./../.env NewInstallation +16041234567 '{\"+17781234567\",\"+17789876543\"}' ./add_buttons.csv.example"
     echo ""
-    echo "The registry CSV file"
+    echo "The buttons CSV file"
     echo "MUST have the header 'button_id,unit,phone_number,button_serial_number'"
     echo "MUST use Unix line endings (LF), or else the phone numbers will have '\r' at the end"
     echo "MUST end with a newline, or else the last button will be silently ignored"
@@ -50,7 +50,7 @@ else
             echo "  Phone Number: $phone_number"
             echo "  Serial Number: $button_serial_number"
 
-            sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -c "INSERT INTO registry (button_id, button_serial_number, unit, phone_number, installation_id) VALUES ('$button_id', '$button_serial_number', '$unit', '$phone_number', '$installation_id');"
+            sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -c "INSERT INTO buttons (button_id, button_serial_number, unit, phone_number, installation_id) VALUES ('$button_id', '$button_serial_number', '$unit', '$phone_number', '$installation_id');"
         fi
     done < $5
 

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -26,7 +26,7 @@ function createSessionFromRow(r) {
 }
 
 function createInstallationFromRow(r) {
-  return new Installation(r.id, r.name, r.responder_phone_number, r.fall_back_phone_number, r.incident_categories, r.is_active, r.created_at)
+  return new Installation(r.id, r.name, r.responder_phone_number, r.fall_back_phone_numbers, r.incident_categories, r.is_active, r.created_at)
 }
 
 function createHubFromRow(r) {
@@ -492,7 +492,7 @@ async function clearButtons(clientParam) {
   }
 }
 
-async function createInstallation(name, responderPhoneNumber, fallbackPhoneNumber, incidentCategories, clientParam) {
+async function createInstallation(name, responderPhoneNumber, fallbackPhoneNumbers, incidentCategories, clientParam) {
   let client = clientParam
   const transactionMode = typeof client !== 'undefined'
 
@@ -502,8 +502,8 @@ async function createInstallation(name, responderPhoneNumber, fallbackPhoneNumbe
     }
 
     await client.query(
-      'INSERT INTO installations (name, responder_phone_number, fall_back_phone_number, incident_categories) VALUES ($1, $2, $3, $4)',
-      [name, responderPhoneNumber, fallbackPhoneNumber, incidentCategories],
+      'INSERT INTO installations (name, responder_phone_number, fall_back_phone_numbers, incident_categories) VALUES ($1, $2, $3, $4)',
+      [name, responderPhoneNumber, fallbackPhoneNumbers, incidentCategories],
     )
   } catch (e) {
     helpers.log(`Error running the createInstallation query: ${e}`)
@@ -853,7 +853,7 @@ async function getDataForExport(clientParam) {
     }
 
     const { rows } = await client.query(
-      `SELECT i.name AS "Installation Name", i.responder_phone_number AS "Responder Phone", i.fall_back_phone_number AS "Fallback Phone", TO_CHAR(i.created_at, 'yyyy-MM-dd HH:mm:ss') AS "Date Installation Created", i.incident_categories AS "Incident Categories", i.is_active AS "Active?", s.unit AS "Unit", s.phone_number AS "Button Phone", s.state AS "Session State", s.num_presses AS "Number of Presses", TO_CHAR(s.created_at, 'yyyy-MM-dd HH:mm:ss') AS "Session Start", TO_CHAR(s.updated_at, 'yyyy-MM-dd HH:mm:ss') AS "Last Session Activity", s.incident_type AS "Session Incident Type", s.notes as "Session Notes", s.fallback_alert_twilio_status AS "Fallback Alert Status (Twilio)", s.button_battery_level AS "Button Battery Level", TO_CHAR(r.created_at, 'yyyy-MM-dd HH:mm:ss') AS "Date Button Created", TO_CHAR(r.updated_at, 'yyyy-MM-dd HH:mm:ss') AS "Button Last Updated", r.button_serial_number AS "Button Serial Number" FROM sessions s JOIN registry r ON s.button_id = r.button_id JOIN installations i ON i.id = s.installation_id`,
+      `SELECT i.name AS "Installation Name", i.responder_phone_number AS "Responder Phone", i.fall_back_phone_numbers AS "Fallback Phones", TO_CHAR(i.created_at, 'yyyy-MM-dd HH:mm:ss') AS "Date Installation Created", i.incident_categories AS "Incident Categories", i.is_active AS "Active?", s.unit AS "Unit", s.phone_number AS "Button Phone", s.state AS "Session State", s.num_presses AS "Number of Presses", TO_CHAR(s.created_at, 'yyyy-MM-dd HH:mm:ss') AS "Session Start", TO_CHAR(s.updated_at, 'yyyy-MM-dd HH:mm:ss') AS "Last Session Activity", s.incident_type AS "Session Incident Type", s.notes as "Session Notes", s.fallback_alert_twilio_status AS "Fallback Alert Status (Twilio)", s.button_battery_level AS "Button Battery Level", TO_CHAR(r.created_at, 'yyyy-MM-dd HH:mm:ss') AS "Date Button Created", TO_CHAR(r.updated_at, 'yyyy-MM-dd HH:mm:ss') AS "Button Last Updated", r.button_serial_number AS "Button Serial Number" FROM sessions s JOIN registry r ON s.button_id = r.button_id JOIN installations i ON i.id = s.installation_id`,
     )
 
     return rows

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1150,8 +1150,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#c2817bb644bea3d741b024bac41a7050682ae8cf",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v2.4.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#1a0a372a15cdb36194bc50df5ebd87ab5efa1969",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v3.0.0",
       "requires": {
         "body-parser": "^1.19.0",
         "chalk": "^4.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.18.3",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v2.4.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v3.0.0",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "express-session": "^1.15.6",

--- a/server/server.js
+++ b/server/server.js
@@ -93,7 +93,7 @@ async function handleValidRequest(button, numPresses, batteryLevel) {
         reminderMessage:
           'Please Respond "Ok" if you have followed up on your call. If you do not respond within 2 minutes an emergency alert will be issued to staff.',
         fallbackMessage: `There has been an unresponded request at ${installation.name} unit ${currentSession.unit.toString()}`,
-        fallbackToPhoneNumber: installation.fallbackPhoneNumber,
+        fallbackToPhoneNumbers: installation.fallbackPhoneNumbers,
         fallbackFromPhoneNumber: helpers.getEnvVar('TWILIO_FALLBACK_FROM_NUMBER'),
       }
       braveAlerter.startAlertSession(alertInfo)
@@ -252,7 +252,7 @@ app.get('/buttons-data', sessionChecker, async (req, res) => {
   const fields = [
     'Installation Name',
     'Responder Phone',
-    'Fallback Phone',
+    'Fallback Phones',
     'Date Installation Created',
     'Incident Categories',
     'Active?',

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -10,3 +10,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USE
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/009-addactiveflag.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/010-addbatteryleveltosessions.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/011-alterfallbackphonenumbertobeanarray.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/012-renameregistrytobuttons.sql

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -9,3 +9,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USE
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/008-alternumpressestonumeric.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/009-addactiveflag.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/010-addbatteryleveltosessions.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/011-alterfallbackphonenumbertobeanarray.sql

--- a/server/setup_server.sh
+++ b/server/setup_server.sh
@@ -46,7 +46,7 @@ else
     n 12.18.3         # keep this in sync with .nvmrc for Travis
     npm ci
 
-    echo "Please enter in order the name and responder phone number and fallback phone number for the first installation (separated by a space):" 
+    echo "Please enter in order the name and responder phone number and one fallback phone number for the first installation (separated by a space):" 
     echo "NOTE that this will have no effect if this script has already been run"
     read installationName responderNumber fallbackNumber
 

--- a/server/test/BraveAlerterConfiguratorTest.js
+++ b/server/test/BraveAlerterConfiguratorTest.js
@@ -34,7 +34,7 @@ describe('BraveAlerterConfigurator', () => {
 
       await db.clearSessions()
       await db.clearInstallations()
-      await db.createInstallation('', this.installationResponderPhoneNumber, '', this.installationIncidentCategories)
+      await db.createInstallation('', this.installationResponderPhoneNumber, '{}', this.installationIncidentCategories)
       const installations = await db.getInstallations()
       await db.createSession(installations[0].id, '', '701', '', 1, null)
       const sessions = await db.getAllSessions()
@@ -83,7 +83,7 @@ describe('BraveAlerterConfigurator', () => {
 
       await db.clearSessions()
       await db.clearInstallations()
-      await db.createInstallation('', this.installationResponderPhoneNumber, '', this.installationIncidentCategories)
+      await db.createInstallation('', this.installationResponderPhoneNumber, '{}', this.installationIncidentCategories)
       const installations = await db.getInstallations()
       await db.createSession(installations[0].id, '', '701', this.sessionToPhoneNumber, 1)
       const sessions = await db.getAllSessions()

--- a/server/test/serverTest.js
+++ b/server/test/serverTest.js
@@ -29,7 +29,7 @@ describe('Chatbot server', () => {
   const unit2PhoneNumber = '+15005550006'
 
   const installationResponderPhoneNumber = '+12345678900'
-  const installationFallbackPhoneNumber = '+12345678900'
+  const installationFallbackPhoneNumbers = ['+12345678900']
   const installationIncidentCategories = ['Accidental', 'Safer Use', 'Overdose', 'Other']
 
   const unit1FlicRequest_SingleClick = {
@@ -78,7 +78,7 @@ describe('Chatbot server', () => {
       await db.createInstallation(
         'TestInstallation',
         installationResponderPhoneNumber,
-        installationFallbackPhoneNumber,
+        installationFallbackPhoneNumbers,
         installationIncidentCategories,
       )
       const installations = await db.getInstallations()
@@ -221,7 +221,7 @@ describe('Chatbot server', () => {
       await db.createInstallation(
         'TestInstallation',
         installationResponderPhoneNumber,
-        installationFallbackPhoneNumber,
+        installationFallbackPhoneNumbers,
         installationIncidentCategories,
       )
       const installations = await db.getInstallations()
@@ -500,7 +500,7 @@ describe('Chatbot server', () => {
       await db.createInstallation(
         'TestInstallation',
         installationResponderPhoneNumber,
-        installationFallbackPhoneNumber,
+        installationFallbackPhoneNumbers,
         installationIncidentCategories,
       )
       const installations = await db.getInstallations()
@@ -814,8 +814,8 @@ describe('Chatbot server', () => {
       expect(sessions.length).to.equal(1)
       expect(sessions[0].state, 'state after reminder timeout has elapsed').to.deep.equal(ALERT_STATE.WAITING_FOR_REPLY)
       expect(sessions[0].fallBackAlertTwilioStatus).to.not.be.null
-      expect(sessions[0].fallBackAlertTwilioStatus).to.not.equal('failed')
-      expect(sessions[0].fallBackAlertTwilioStatus).to.not.equal('undelivered')
+      expect(sessions[0].fallBackAlertTwilioStatus).to.not.equal('failed, ')
+      expect(sessions[0].fallBackAlertTwilioStatus).to.not.equal('undelivered, ')
       expect(sessions[0].fallBackAlertTwilioStatus).to.be.oneOf(['queued', 'sent', 'delivered'])
     })
   })


### PR DESCRIPTION
- Upgraded version of brave-alert-lib (https://github.com/bravetechnologycoop/brave-alert-lib/pull/10) takes an array of phone numbers for the fallbackPhoneNumbers parameter instead of just one.
- Changed `installations.fall_back_phone_number` column in the DB to be an text array, renamed it `fall_back_phone_numbers`, and migrated the current value in `fall_back_phone_number` into an array containing the old value.
- Updated tests accordingly
- Note that setup_server.sh 's script still only expects a single fallback number because at the point of running the migration file that needs that parameter, the column is still only expecting a text string containing a single phone number

- Tested this on chatbot dev:
   - The fallback messages are sent to multiple phones
   - Export CSV with an array of fallback phone numbers and the Twilio return values from multiple fallback message attempts
   - add_installation.sh script with an array of fallback phone numbers
   - Database migration with values in the DB