### PR TITLE
Always update the numPresses of the most recent unresponded session (CU-tb9pvc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Fixes
+- Now always gets the most recent unresponded session (CU-tb9pvc).
+
 ## [3.5.0] - 2021-04-19
 
 ### Added

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -96,7 +96,7 @@ async function getUnrespondedSessionWithButtonId(buttonId, clientParam) {
       client = await pool.connect()
     }
 
-    const query = 'SELECT * FROM sessions WHERE button_id = $1 AND state != $2 AND state != $3 AND state != $4'
+    const query = 'SELECT * FROM sessions WHERE button_id = $1 AND state != $2 AND state != $3 AND state != $4 ORDER BY created_at DESC LIMIT 1'
     const values = [buttonId, ALERT_STATE.WAITING_FOR_CATEGORY, ALERT_STATE.WAITING_FOR_DETAILS, ALERT_STATE.COMPLETED]
     const { rows } = await client.query(query, values)
 


### PR DESCRIPTION
- This fixes a bug that only appears in our last release because we
  now allow multiple sessions to be left in "Waiting for Reply".
  This ensures that it will only get the most recent of those sessions.