### PR TITLE
heartbeat.py - updates to run loop timing, added HTTP retry (CU-mrz5r1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ the code was deployed.
 ### Changed
 
 - Improved some API error messages.
+- `heartbeat.py` extra delay in run loop now depends on run loop duration (CU-mrz5r1).
+- `heartbeat.py` now retries the heartbeat HTTP request once before turning off the Flic hub.
 
 ## [3.5.1] - 2021-04-19
 

--- a/pi/heartbeat.py
+++ b/pi/heartbeat.py
@@ -151,6 +151,7 @@ def send_heartbeat(flic_last_seen_secs, flic_last_ping_secs, system_id):
 last_ping = datetime.datetime.now()
 
 def gather_stats():
+    global last_ping
     html = get_darkstat_html()
     ip = parse_flic_ip_from_darkstat_html(html, FLIC_MAC_ADDRESS)
     if ping(ip):

--- a/pi/heartbeat.py
+++ b/pi/heartbeat.py
@@ -211,6 +211,7 @@ if __name__ == '__main__':
                     # if the issue was a timeout error and the retry works, this will avoid turning off the Flic hub
                     num_secs_darkstat, num_secs_ping = gather_stats()
                     system_ok = send_heartbeat(num_secs_darkstat, num_secs_ping, system_id)
+                    logging.info('retried heartbeat request, system_ok is %s', system_ok)
             except FlicNotFoundError as e:
                 # this means that the flic didn't show up in darkstat's list of hosts
                 # typically this happens on startup for a few seconds until the flic becomes active on the network

--- a/pi/heartbeat.py
+++ b/pi/heartbeat.py
@@ -162,7 +162,6 @@ def gather_stats():
 # run the loop at most once every N seconds (N = min_delay)
 # if the run loop takes longer then N seconds we don't need to sleep
 def run_loop_delay(min_delay, last_run_time):
-
     run_loop_duration = (datetime.datetime.now() - last_run_time).total_seconds()
     sleep_time = max(min_delay - run_loop_duration, 0.0)
     time.sleep(sleep_time)

--- a/pi/test_heartbeat.py
+++ b/pi/test_heartbeat.py
@@ -37,7 +37,7 @@ class Test__parse_flic_last_seen_from_darkstat_html(object):
     
     def test_log_last_seen_when_darkstat_html_contains_flic_mac_address(self):
         file_path = os.path.dirname(__file__) + '/test_files/sample_darkstat_html/log_last_seen.html'
-        with open(file_path, 'r') as html_file, unittest.mock.patch('heartbeat.logging') as mock_logging:
+        with open(file_path, 'r') as html_file, patch('heartbeat.logging') as mock_logging:
             html = html_file.read()
             heartbeat.parse_flic_last_seen_from_darkstat_html(html, '00:00:00:00:00:02')
 
@@ -52,7 +52,7 @@ class Test__parse_flic_ip_from_darkstat_html(object):
 
     def test_log_ip_when_darkstat_html_contains_flic_mac_address(self):
         file_path = os.path.dirname(__file__) + '/test_files/sample_darkstat_html/log_ip.html'
-        with open(file_path, 'r') as html_file, unittest.mock.patch('heartbeat.logging') as mock_logging:
+        with open(file_path, 'r') as html_file, patch('heartbeat.logging') as mock_logging:
             html = html_file.read()
             heartbeat.parse_flic_ip_from_darkstat_html(html, '00:00:00:00:00:02')
 
@@ -61,47 +61,41 @@ class Test__parse_flic_ip_from_darkstat_html(object):
 class Test__parse_link_quality_from_iwconfig_output(object):
 
     def test_link_quality_1(self):
-        with open(os.path.dirname(__file__) + '/test_files/sample_iwconfig_output/link_quality_1.txt', 'r') as iwconfig_output_file:
-            with unittest.mock.patch('heartbeat.logging') as mock_logging:
-                iwconfig_output = iwconfig_output_file.read()
-                heartbeat.parse_link_quality_from_iwconfig_output(iwconfig_output)
-                mock_logging.info.assert_called_once_with('wlan0 link quality is %f', 1.0)
+        with open(os.path.dirname(__file__) + '/test_files/sample_iwconfig_output/link_quality_1.txt', 'r') as output_file, patch('heartbeat.logging') as mock_logging:
+            iwconfig_output = output_file.read()
+            heartbeat.parse_link_quality_from_iwconfig_output(iwconfig_output)
+            mock_logging.info.assert_called_once_with('wlan0 link quality is %f', 1.0)
 
     def test_link_quality_half(self):
-        with open(os.path.dirname(__file__) + '/test_files/sample_iwconfig_output/link_quality_half.txt', 'r') as iwconfig_output_file:
-            with unittest.mock.patch('heartbeat.logging') as mock_logging:
-                iwconfig_output = iwconfig_output_file.read()
-                heartbeat.parse_link_quality_from_iwconfig_output(iwconfig_output)
-                mock_logging.info.assert_called_once_with('wlan0 link quality is %f', 0.5)
+        with open(os.path.dirname(__file__) + '/test_files/sample_iwconfig_output/link_quality_half.txt', 'r') as output_file, patch('heartbeat.logging') as mock_logging:
+            iwconfig_output = output_file.read()
+            heartbeat.parse_link_quality_from_iwconfig_output(iwconfig_output)
+            mock_logging.info.assert_called_once_with('wlan0 link quality is %f', 0.5)
 
     def test_no_wlan0_in_output(self):
-        with open(os.path.dirname(__file__) + '/test_files/sample_iwconfig_output/no_wlan0.txt', 'r') as iwconfig_output_file:
-            with unittest.mock.patch('heartbeat.logging') as mock_logging:
-                iwconfig_output = iwconfig_output_file.read()
-                heartbeat.parse_link_quality_from_iwconfig_output(iwconfig_output)
-                mock_logging.warning.assert_called_once_with('error parsing iwconfig output')
+        with open(os.path.dirname(__file__) + '/test_files/sample_iwconfig_output/no_wlan0.txt', 'r') as output_file, patch('heartbeat.logging') as mock_logging:
+            iwconfig_output = output_file.read()
+            heartbeat.parse_link_quality_from_iwconfig_output(iwconfig_output)
+            mock_logging.warning.assert_called_once_with('error parsing iwconfig output')
 
 class Test__ping(object):
 
     def test_localhost(self):
         assert heartbeat.ping('localhost')
-    
+
     def test_log_command(self):
-        with unittest.mock.patch('heartbeat.logging') as mock_logging:
+        with patch('heartbeat.logging') as mock_logging:
             heartbeat.ping('localhost')
-
             mock_logging.info.assert_any_call('running: [\'ping\', \'-c\', \'1\', \'localhost\']')
-    
-    def test_log_when_successful(self):
-        with unittest.mock.patch('heartbeat.logging') as mock_logging:
-            heartbeat.ping('localhost')
 
+    def test_log_when_successful(self):
+        with patch('heartbeat.logging') as mock_logging:
+            heartbeat.ping('localhost')
             mock_logging.info.assert_called_with('returned: 0')
 
     def test_log_when_errored(self):
-        with unittest.mock.patch('heartbeat.logging') as mock_logging:
+        with patch('heartbeat.logging') as mock_logging:
             heartbeat.ping('invalid-ip')
-
             mock_logging.info.assert_called_with('returned: 2')
 
 class Test__get_system_id_from_path(object):
@@ -124,54 +118,54 @@ class Test__get_system_id_from_path(object):
 class Test__send_heartbeat(object):
 
     def test_when_heartbeat_server_is_working(self):
-        with unittest.mock.patch('http.client.HTTPSConnection') as MockHTTPSConnection:
-                mock_connection = MockHTTPSConnection.return_value
-                mock_response = unittest.mock.MagicMock()
-                mock_response.status = 200
-                mock_connection.getresponse.return_value = mock_response
-                mock_connection.request = unittest.mock.MagicMock()
+        with patch('http.client.HTTPSConnection') as MockHTTPSConnection:
+            mock_connection = MockHTTPSConnection.return_value
+            mock_response = unittest.mock.MagicMock()
+            mock_response.status = 200
+            mock_connection.getresponse.return_value = mock_response
+            mock_connection.request = unittest.mock.MagicMock()
 
-                system_id = 'b90e1fc0-53d3-42ba-8bf6-83453e6af744'
-                flic_last_seen_secs = 5
-                flic_last_ping_secs = 3
-                success = heartbeat.send_heartbeat(flic_last_seen_secs, flic_last_ping_secs, system_id)
+            system_id = 'b90e1fc0-53d3-42ba-8bf6-83453e6af744'
+            flic_last_seen_secs = 5
+            flic_last_ping_secs = 3
+            success = heartbeat.send_heartbeat(flic_last_seen_secs, flic_last_ping_secs, system_id)
 
-                assert success == True
-                assert mock_connection.request.called
+            assert success == True
+            assert mock_connection.request.called
 
     def test_when_heartbeat_server_is_not_working(self):
-        with unittest.mock.patch('http.client.HTTPSConnection') as MockHTTPSConnection:
-                mock_connection = MockHTTPSConnection.return_value
-                mock_response = unittest.mock.MagicMock()
-                mock_response.status = 500
-                mock_connection.getresponse.return_value = mock_response
-                mock_connection.request = unittest.mock.MagicMock()
+        with patch('http.client.HTTPSConnection') as MockHTTPSConnection:
+            mock_connection = MockHTTPSConnection.return_value
+            mock_response = unittest.mock.MagicMock()
+            mock_response.status = 500
+            mock_connection.getresponse.return_value = mock_response
+            mock_connection.request = unittest.mock.MagicMock()
 
-                system_id = 'b90e1fc0-53d3-42ba-8bf6-83453e6af744'
-                flic_last_seen_secs = 5
-                flic_last_ping_secs = 3
-                success = heartbeat.send_heartbeat(flic_last_seen_secs, flic_last_ping_secs, system_id)
+            system_id = 'b90e1fc0-53d3-42ba-8bf6-83453e6af744'
+            flic_last_seen_secs = 5
+            flic_last_ping_secs = 3
+            success = heartbeat.send_heartbeat(flic_last_seen_secs, flic_last_ping_secs, system_id)
 
-                assert success == False
-                assert mock_connection.request.called
+            assert success == False
+            assert mock_connection.request.called
 
     def test_when_request_times_out(self):
-        with unittest.mock.patch('http.client.HTTPSConnection') as MockHTTPSConnection:
-                mock_connection = MockHTTPSConnection.return_value
-                mock_connection.request = unittest.mock.MagicMock(side_effect=socket.timeout())
+        with patch('http.client.HTTPSConnection') as MockHTTPSConnection:
+            mock_connection = MockHTTPSConnection.return_value
+            mock_connection.request = unittest.mock.MagicMock(side_effect=socket.timeout())
 
-                system_id = 'b90e1fc0-53d3-42ba-8bf6-83453e6af744'
-                flic_last_seen_secs = 5
-                flic_last_ping_secs = 3
-                success = heartbeat.send_heartbeat(flic_last_seen_secs, flic_last_ping_secs, system_id)
+            system_id = 'b90e1fc0-53d3-42ba-8bf6-83453e6af744'
+            flic_last_seen_secs = 5
+            flic_last_ping_secs = 3
+            success = heartbeat.send_heartbeat(flic_last_seen_secs, flic_last_ping_secs, system_id)
 
-                assert success == False
-                assert mock_connection.request.called
+            assert success == False
+            assert mock_connection.request.called
 
 class Test__get_darkstat_html(object):
 
     def test_return_value(self):
-        with unittest.mock.patch('http.client.HTTPConnection') as MockHTTPConnection:
+        with patch('http.client.HTTPConnection') as MockHTTPConnection:
             mock_connection = MockHTTPConnection.return_value
             mock_response = unittest.mock.MagicMock()
             mock_connection.getresponse.return_value = mock_response
@@ -181,7 +175,7 @@ class Test__get_darkstat_html(object):
             assert test_html == heartbeat.get_darkstat_html()
 
     def test_when_request_times_out(self):
-        with unittest.mock.patch('http.client.HTTPConnection') as MockHTTPConnection:
+        with patch('http.client.HTTPConnection') as MockHTTPConnection:
             mock_connection = MockHTTPConnection.return_value
             mock_connection.request = unittest.mock.MagicMock(side_effect=socket.timeout())
 

--- a/pi/test_heartbeat.py
+++ b/pi/test_heartbeat.py
@@ -3,6 +3,10 @@ import pytest
 import unittest.mock
 import socket
 import os
+import time
+import datetime
+
+patch = unittest.mock.patch
 
 class Test__parse_flic_last_seen_from_darkstat_html(object):
 
@@ -182,4 +186,22 @@ class Test__get_darkstat_html(object):
             mock_connection.request = unittest.mock.MagicMock(side_effect=socket.timeout())
 
             assert '' == heartbeat.get_darkstat_html()
+
+class Test__run_loop_delay(object):
+
+    def test_with_no_computation_time(self):
+        last_run_time = datetime.datetime.now()
+        with patch('time.sleep') as mock_sleep, patch('datetime.datetime') as mock_datetime:
+            # fictional run loop computation takes 0 time
+            mock_datetime.now.return_value = last_run_time
+            heartbeat.run_loop_delay(1.0, last_run_time)
+            mock_sleep.assert_called_once_with(1.0)
+
+    def test_with_computation_time(self):
+        last_run_time = datetime.datetime.now()
+        with patch('time.sleep') as mock_sleep, patch('datetime.datetime') as mock_datetime:
+            # simulate some computation that occurs before run_loop_delay() is called
+            mock_datetime.now.return_value = last_run_time + datetime.timedelta(seconds=0.5)
+            heartbeat.run_loop_delay(1.0, last_run_time)
+            mock_sleep.assert_called_once_with(0.5)
 

--- a/pi/test_heartbeat.py
+++ b/pi/test_heartbeat.py
@@ -199,3 +199,18 @@ class Test__run_loop_delay(object):
             heartbeat.run_loop_delay(1.0, last_run_time)
             mock_sleep.assert_called_once_with(0.5)
 
+    def test_with_computation_time_equal_to_min_delay(self):
+        last_run_time = datetime.datetime.now()
+        with patch('time.sleep') as mock_sleep, patch('datetime.datetime') as mock_datetime:
+            # simulate some computation that takes exactly as long as the desired delay time
+            mock_datetime.now.return_value = last_run_time + datetime.timedelta(seconds=1.0)
+            heartbeat.run_loop_delay(1.0, last_run_time)
+            mock_sleep.assert_called_once_with(0.0)
+
+    def test_with_long_computation_time(self):
+        last_run_time = datetime.datetime.now()
+        with patch('time.sleep') as mock_sleep, patch('datetime.datetime') as mock_datetime:
+            # simulate some long-running computation that occurs before run_loop_delay() is called
+            mock_datetime.now.return_value = last_run_time + datetime.timedelta(seconds=10.0)
+            heartbeat.run_loop_delay(1.0, last_run_time)
+            mock_sleep.assert_called_once_with(0.0)


### PR DESCRIPTION
- extra delay in run loop now depends on run loop duration
- the script now retries the heartbeat HTTP request once before turning off the Flic hub