### PR TITLE
Update Brave Alert Lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ the code was deployed.
 
 ## Unreleased
 
+### Changed
+
+- logSentry calls appear as messages instead of exceptions (CU-32a5wb).
+
+### Fixed
+
+- Error log for /alert/sms now has the correct route name.
+
 ## [3.7.0] - 2021-05-21
 
 ### Changed

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -524,83 +524,76 @@
       "dev": true
     },
     "@sentry/core": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.5.tgz",
-      "integrity": "sha512-VR2ibDy33mryD0mT6d9fGhKjdNzS2FSwwZPe9GvmNOjkyjly/oV91BKVoYJneCqOeq8fyj2lvkJGKuupdJNDqg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.4.1.tgz",
+      "integrity": "sha512-Lx13oTiP+Tjvm5VxulcCszNVd2S1wY4viSnr+ygq62ySVERR+t7uOZDSARZ0rZ259GwW6nkbMh9dDmD0d6VCGQ==",
       "requires": {
-        "@sentry/hub": "6.3.5",
-        "@sentry/minimal": "6.3.5",
-        "@sentry/types": "6.3.5",
-        "@sentry/utils": "6.3.5",
+        "@sentry/hub": "6.4.1",
+        "@sentry/minimal": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.5.tgz",
-      "integrity": "sha512-ZYFo7VYKwdPVjuV9BDFiYn+MpANn6eZMz5QDBfZ2dugIvIVbuOyOOLx8PSa3ZXJoVTZZ7s2wD2fi/ZxKjNjZOQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.4.1.tgz",
+      "integrity": "sha512-7IZRP5buDE6s/c3vWzzPR/ySE+8GUuHPgTEPiDCPOCWwUN11zXDafJDKkJqY3muJfebUKmC/JG67RyBx+XlnlQ==",
       "requires": {
-        "@sentry/types": "6.3.5",
-        "@sentry/utils": "6.3.5",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.5.tgz",
-      "integrity": "sha512-4RqIGAU0+8iI/1sw0GYPTr4SUA88/i2+JPjFJ+qloh5ANVaNwhFPRChw+Ys9xpre8LV9JZrEsEf8AvQr4fkNbA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.4.1.tgz",
+      "integrity": "sha512-4x/PRbDZACCKJqjta9EkhiIMyGMf7VgBX13EEWEDVWLP7ymFukBuTr4ap/Tz9429kB/yXZuDGGMIZp/G618H3g==",
       "requires": {
-        "@sentry/hub": "6.3.5",
-        "@sentry/types": "6.3.5",
+        "@sentry/hub": "6.4.1",
+        "@sentry/types": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.3.5.tgz",
-      "integrity": "sha512-scPB+DoAEPaqkYuyb8d/gVWbFmX5PhaYSNHybeHncaP/P4itLdq/AoAWGNxl0Hj4EQokfT4OZWxaaJi7SCYnaw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.4.1.tgz",
+      "integrity": "sha512-w4IFRA7UFZxKL9xVXmQU8eAjVMY/sr0fJcTV8Wma4uZqa1FQVX4p6xgfylLrcaA8VsolE3l9LRrP1XYxCVwvOw==",
       "requires": {
-        "@sentry/core": "6.3.5",
-        "@sentry/hub": "6.3.5",
-        "@sentry/tracing": "6.3.5",
-        "@sentry/types": "6.3.5",
-        "@sentry/utils": "6.3.5",
+        "@sentry/core": "6.4.1",
+        "@sentry/hub": "6.4.1",
+        "@sentry/tracing": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-        }
       }
     },
     "@sentry/tracing": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.3.5.tgz",
-      "integrity": "sha512-TNKAST1ge2g24BlTfVxNp4gP5t3drbi0OVCh8h8ah+J7UjHSfdiqhd9W2h5qv1GO61gGlpWeN/TyioyQmOxu0Q==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.4.1.tgz",
+      "integrity": "sha512-EPRadE9n/wpUjx4jqP/8vXdOAZBk7vjlzRKniJgKgQUO3v03i0ui6xydaal2mvhplIyOCI2muXdGhjUO7ga4uw==",
       "requires": {
-        "@sentry/hub": "6.3.5",
-        "@sentry/minimal": "6.3.5",
-        "@sentry/types": "6.3.5",
-        "@sentry/utils": "6.3.5",
+        "@sentry/hub": "6.4.1",
+        "@sentry/minimal": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.5.tgz",
-      "integrity": "sha512-tY/3pkAmGYJ3F0BtwInsdt/uclNvF8aNG7XHsTPQNzk7BkNVWjCXx0sjxi6CILirl5nwNxYxVeTr2ZYAEZ/dSQ=="
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.4.1.tgz",
+      "integrity": "sha512-sTu/GaLsLYk1AkAqpkMT4+4q665LtZjhV0hkgiTD4N3zPl5uSf1pCIzxPRYjOpe7NEANmWv8U4PaGKGtc2eMfA=="
     },
     "@sentry/utils": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.5.tgz",
-      "integrity": "sha512-kHUcZ37QYlNzz7c9LVdApITXHaNmQK7+sw/If3M/qpff1fd5XoecA8laLfcYuz+Cw5mRhVmdhPcCRM3Xi1IGXg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.4.1.tgz",
+      "integrity": "sha512-xJ1uVa5fvg23pXQfulvCIBb9pQ3p1awyd1PapK2AYi+wKjTuYl4B9edmhjRREEQEExznl/d2OVm78fRXLq7M9Q==",
       "requires": {
-        "@sentry/types": "6.3.5",
+        "@sentry/types": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
@@ -1059,8 +1052,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#670289913a076d5b2c7c82542a1b7ed28bd9100b",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v3.2.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#66cb40c57968ffbc69dda09a1b709c8a40619069",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v3.3.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.18.3",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v3.2.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v3.3.0",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "express-session": "^1.15.6",


### PR DESCRIPTION
- To change `logSentry` to a message instead of an error
- To fix the route in handleTwilioMessage error messages
- ~~Didn't update the CHANGELOG because these two changes are modifications of things that already have an entry in the upcoming release's CHANGELOG.~~

Tested this by
- Deploying on `chatbot-dev`
- Replied to a Button-press alert with a phone that wasn't the Responder phone, and got the error message `21|BraveServer  | 2021-05-13 23:23:25.853: Bad request to /alert/sms: Invalid Phone Number`
- Manually changed the values in the `hubs` table to simulate a Hub reconnecting and disconnecting. This made a Sentry info message that looks like this: https://sentry.io/organizations/brave-technology-coop/issues/2397959388/?project=5743498&query=&statsPeriod=14d