### PR TITLE
Fix PM2 issues after Ubuntu 20.04 upgrade (CU-w5g52f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ the code was deployed.
 ### Fixed
 
 - Error log for /alert/sms now has the correct route name.
+- Setup script (CU-w5g52f).
 
 ## [3.7.0] - 2021-05-21
 

--- a/server/setup_server.sh
+++ b/server/setup_server.sh
@@ -3,7 +3,6 @@
 set -e
 original_dir=$(pwd)
 cd $(dirname "$0")
-export HOME=$(bash <<< "echo ~$SUDO_USER")
 
 if [[ $EUID > 0 ]]; then
     echo "this script needs sudo privelages to run correctly."
@@ -56,7 +55,7 @@ else
     # restart server weekly to ensure it uses the latest certificates (certbot renews them automatically)
     echo "
     PATH=/bin:/usr/bin:/usr/local/bin
-    @weekly env HOME=$HOME pm2 restart BraveServer
+    @weekly env pm2 restart BraveServer
     " | crontab -
 
     pm2 install pm2-logrotate


### PR DESCRIPTION
- After upgrading to Ubuntu 20.04, the version of pm2 that we use
  changed from 3.5.1 to 4.5.6
- For some reason, this meant that running the `setup_server.sh` as
  it was and also the scheduled `pm2 restart` cron job failed to
  properly restart the job. Instead, they would do weird things like
  spawning a new server.js node process but not kill the old one, so
  the server would still be running the old code. Other times, it
  would leave the `pm2 status` view with no running code. Very strange
- I'm not sure why this change works, but I've played around with it
  and also with using `pm2 save` at various points and this seems to
  do the trick.

My definition of "a working state":
1. When I run `sudo pm2 status`, I see BraveServer and pm2-logrotate running:
![image](https://user-images.githubusercontent.com/1490437/120044038-e9616680-bfc1-11eb-94a2-5044c438c326.png)
2. When I run `ps aux | grep 'node'`, I see only one node process running `server.js`:
```
brave@button-server-dev:~/BraveButtons/server$ ps aux | grep 'node'
root      130889  0.4  4.4 796644 44232 ?        Ssl  20:10   0:17 node /root/.pm2/modules/pm2-logrotate/node_modules/pm2-logrotate
root      131133  1.2  7.6 823316 76848 ?        Ssl  21:00   0:12 node /home/brave/BraveButtons/server/server.js
brave     131185  0.0  0.0   8160   660 pts/0    S+   21:16   0:00 grep --color=auto node
```
3. Changes made to `heartbeatDashboard.mst` since the previous deployment attempt appear in https://chatbot-dev.brave.coop/heartbeatDashboard (this represents to me that any new code changes would have been deployed)

I tested this by:
- Given I'm already in a working state. When I run `sudo ./setup_server.sh .env` . Then I am in a working state again.
- Given I'm already in a working state. When the cron job runs. Then I am in a working state again.
- Given I have killed all `node` processes using `sudo pkill node` (note that from where I am now, the pm2-logrotate restarts itself after `sudo pkill node`, so it is still running in this case). When I run `sudo ./setup_server.sh .env`. Then I am in a working state.