### PR TITLE
Remove POST / endpoint (CU-fmunf5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ the code was deployed.
 
 - Error log for /alert/sms now has the correct route name.
 
+### Removed
+
+- `POST /` endpoint (CU-fmunf5).
+
 ## [3.7.0] - 2021-05-21
 
 ### Changed

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -378,35 +378,6 @@ async function clearSessions(clientParam) {
   }
 }
 
-async function getButtonWithButtonId(buttonId, clientParam) {
-  let client = clientParam
-  const transactionMode = typeof client !== 'undefined'
-
-  try {
-    if (!transactionMode) {
-      client = await pool.connect()
-    }
-
-    const { rows } = await client.query('SELECT * FROM buttons WHERE button_id = $1', [buttonId])
-
-    if (rows.length > 0) {
-      return rows[0]
-    }
-  } catch (e) {
-    helpers.logError(`Error running the getButtonWithButtonId query: ${e}`)
-  } finally {
-    if (!transactionMode) {
-      try {
-        client.release()
-      } catch (err) {
-        helpers.logError(`getButtonWithButtonId: Error releasing client: ${err}`)
-      }
-    }
-  }
-
-  return null
-}
-
 async function getButtonWithSerialNumber(serialNumber, clientParam) {
   let client = clientParam
   const transactionMode = typeof client !== 'undefined'
@@ -946,7 +917,6 @@ module.exports = {
   createSession,
   getAllSessions,
   getAllSessionsWithButtonId,
-  getButtonWithButtonId,
   getButtonWithSerialNumber,
   getCurrentTime,
   getDataForExport,

--- a/server/server.js
+++ b/server/server.js
@@ -315,44 +315,10 @@ app.post('/flic_button_press', Validator.header(['button-serial-number']).exists
       } else {
         await handleValidRequest(button, 1, batteryLevel)
 
-        // eslint-disable-next-line eqeqeq
-        if (req.query.presses == 2) {
-          await handleValidRequest(button, 1, batteryLevel)
-        }
-
         res.status(200).send()
       }
     } else {
       const errorMessage = `Bad request to ${req.path}: ${validationErrors.array()}`
-      helpers.logError(errorMessage)
-      res.status(400).send(errorMessage)
-    }
-  } catch (err) {
-    helpers.logError(err)
-    res.status(500).send()
-  }
-})
-
-app.post('/', jsonBodyParser, async (req, res) => {
-  try {
-    const requiredBodyParams = ['UUID', 'Type']
-
-    if (helpers.isValidRequest(req, requiredBodyParams)) {
-      const button = await db.getButtonWithButtonId(req.body.UUID)
-      if (button === null) {
-        helpers.logError(`Bad request to /: UUID is not registered. UUID is ${req.body.UUID}`)
-        res.status(400).send('Bad request to /: UUID is not registered')
-      } else {
-        await handleValidRequest(button, 0.5)
-
-        if (req.body.Type.startsWith('double')) {
-          await handleValidRequest(button, 0.5)
-        }
-
-        res.status(200).send()
-      }
-    } else {
-      const errorMessage = 'Bad request to /: UUID or Type is missing'
       helpers.logError(errorMessage)
       res.status(400).send(errorMessage)
     }


### PR DESCRIPTION
- No longer using it anywhere in production
- Removed the `presses` argument to `POST /flic_button_press` because it is also is not being used in production.
- Updated tests accordingly

THIS WILL BE A BREAKING CHANGE.

How I tested this:
- Tests pass on Travis
- Deployed to chatbot-dev
- Used Postman to hit `POST /flic_button_press` to simulate button presses in the following scenarios:
   - Respond right away to the full chatbot
   - Do not respond until after the reminder and the fallback have been sent
   - Multiple presses to see urgent message at 2nd message and every 5th message
- Took a peek at Dashboard and Heartbeat dashboard and both look normal
- Used Postman to hit `POST /` and make sure that it returns a 404
- Used Postman to hit `POST /flic_button_press?presses=2` to make sure that it isn't counting this as two button presses anymore.