### PR TITLE
Add GET /alert/historicAlerts endpoint and `sessions.responded_at` column (CU-hjwfx2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ matrix:
         - REMINDER_TIMEOUT_MS_TEST=1000
         - FALLBACK_TIMEOUT_MS_TEST=2000
         - FLIC_BUTTON_PRESS_API_KEY_TEST=testFlicApiKey
+        - SESSION_RESET_TIMEOUT_TEST=7200000
 
       # setup database
       before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ the code was deployed.
 ### Added
 
 - Mocha debugging configuration for `/server`.
+- `GET /alert/historicAlerts` endpoint (CU-hjwfx2).
+- Tracking of when sessions are first responded to (CU-hjwfx2).
 
 ## [4.0.0] - 2021-06-15
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -72,3 +72,7 @@ SENTRY_ENVIRONMENT=exampleenvironment
 
 # Release tag for Sentry
 SENTRY_RELEASE=examplerelease
+
+# Any new Button presses after a period of this much inactivity will start a new session
+SESSION_RESET_TIMEOUT=7200000
+SESSION_RESET_TIMEOUT_TEST=7200000

--- a/server/SessionState.js
+++ b/server/SessionState.js
@@ -1,6 +1,6 @@
 class SessionState {
   // prettier-ignore
-  constructor(id, installationId, buttonId, unit, phoneNumber, state, numPresses, createdAt, updatedAt, incidentType, notes, fallBackAlertTwilioStatus, buttonBatteryLevel) {
+  constructor(id, installationId, buttonId, unit, phoneNumber, state, numPresses, createdAt, updatedAt, incidentType, notes, fallBackAlertTwilioStatus, buttonBatteryLevel, respondedAt) {
     this.id = id
     this.installationId = installationId
     this.buttonId = buttonId
@@ -14,6 +14,7 @@ class SessionState {
     this.notes = notes
     this.fallBackAlertTwilioStatus = fallBackAlertTwilioStatus
     this.buttonBatteryLevel = buttonBatteryLevel
+    this.respondedAt = respondedAt
   }
 
   incrementButtonPresses(numPresses) {

--- a/server/chatbotDashboard.mst
+++ b/server/chatbotDashboard.mst
@@ -202,6 +202,7 @@
                                 <th scope="col">Notes</th>
                                 <th scope="col">Started At</th>
                                 <th scope="col">Updated At</th>
+                                <th scope="col">Responded At</th>
                                 <th scope="col">Battery Level</th>
                             </tr>
                         </thead>
@@ -215,6 +216,7 @@
                                     <td>{{notes}}</td>
                                     <td>{{createdAt}}</td>
                                     <td>{{updatedAt}}</td>
+                                    <td>{{respondedAt}}</td>
                                     <td>{{buttonBatteryLevel}}</td>
                                 </tr>
                             {{/recentSessions}}

--- a/server/db/014-addrespondedattosessions.sql
+++ b/server/db/014-addrespondedattosessions.sql
@@ -1,0 +1,21 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 14;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        ALTER TABLE sessions 
+        ADD COLUMN responded_at timestamptz;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -524,47 +524,47 @@
       "dev": true
     },
     "@sentry/core": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.4.1.tgz",
-      "integrity": "sha512-Lx13oTiP+Tjvm5VxulcCszNVd2S1wY4viSnr+ygq62ySVERR+t7uOZDSARZ0rZ259GwW6nkbMh9dDmD0d6VCGQ==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.7.2.tgz",
+      "integrity": "sha512-NTZqwN5nR94yrXmSfekoPs1mIFuKvf8esdIW/DadwSKWAdLJwQTJY9xK/8PQv+SEzd7wiitPAx+mCw2By1xiNQ==",
       "requires": {
-        "@sentry/hub": "6.4.1",
-        "@sentry/minimal": "6.4.1",
-        "@sentry/types": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/hub": "6.7.2",
+        "@sentry/minimal": "6.7.2",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.4.1.tgz",
-      "integrity": "sha512-7IZRP5buDE6s/c3vWzzPR/ySE+8GUuHPgTEPiDCPOCWwUN11zXDafJDKkJqY3muJfebUKmC/JG67RyBx+XlnlQ==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.7.2.tgz",
+      "integrity": "sha512-05qVW6ymChJsXag4+fYCQokW3AcABIgcqrVYZUBf6GMU/Gbz5SJqpV7y1+njwWvnPZydMncP9LaDVpMKbE7UYQ==",
       "requires": {
-        "@sentry/types": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.4.1.tgz",
-      "integrity": "sha512-4x/PRbDZACCKJqjta9EkhiIMyGMf7VgBX13EEWEDVWLP7ymFukBuTr4ap/Tz9429kB/yXZuDGGMIZp/G618H3g==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.7.2.tgz",
+      "integrity": "sha512-jkpwFv2GFHoVl5vnK+9/Q+Ea8eVdbJ3hn3/Dqq9MOLFnVK7ED6MhdHKLT79puGSFj+85OuhM5m2Q44mIhyS5mw==",
       "requires": {
-        "@sentry/hub": "6.4.1",
-        "@sentry/types": "6.4.1",
+        "@sentry/hub": "6.7.2",
+        "@sentry/types": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.4.1.tgz",
-      "integrity": "sha512-w4IFRA7UFZxKL9xVXmQU8eAjVMY/sr0fJcTV8Wma4uZqa1FQVX4p6xgfylLrcaA8VsolE3l9LRrP1XYxCVwvOw==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.7.2.tgz",
+      "integrity": "sha512-vfNTmxBbHthAKPDBo0gVk/aNHdgUfXLzmaK7FgWO7cISiI2soCfvKEIP61XqIFZru06teqcRuDsYlR4wSeyWpg==",
       "requires": {
-        "@sentry/core": "6.4.1",
-        "@sentry/hub": "6.4.1",
-        "@sentry/tracing": "6.4.1",
-        "@sentry/types": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/core": "6.7.2",
+        "@sentry/hub": "6.7.2",
+        "@sentry/tracing": "6.7.2",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -572,28 +572,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.4.1.tgz",
-      "integrity": "sha512-EPRadE9n/wpUjx4jqP/8vXdOAZBk7vjlzRKniJgKgQUO3v03i0ui6xydaal2mvhplIyOCI2muXdGhjUO7ga4uw==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.7.2.tgz",
+      "integrity": "sha512-juKlI7FICKONWJFJxDxerj0A+8mNRhmtrdR+OXFqOkqSAy/QXlSFZcA/j//O19k2CfwK1BrvoMcQ/4gnffUOVg==",
       "requires": {
-        "@sentry/hub": "6.4.1",
-        "@sentry/minimal": "6.4.1",
-        "@sentry/types": "6.4.1",
-        "@sentry/utils": "6.4.1",
+        "@sentry/hub": "6.7.2",
+        "@sentry/minimal": "6.7.2",
+        "@sentry/types": "6.7.2",
+        "@sentry/utils": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.4.1.tgz",
-      "integrity": "sha512-sTu/GaLsLYk1AkAqpkMT4+4q665LtZjhV0hkgiTD4N3zPl5uSf1pCIzxPRYjOpe7NEANmWv8U4PaGKGtc2eMfA=="
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.7.2.tgz",
+      "integrity": "sha512-h21Go/PfstUN+ZV6SbwRSZVg9GXRJWdLfHoO5PSVb3TVEMckuxk8tAE57/u+UZDwX8wu+Xyon2TgsKpiWKxqUg=="
     },
     "@sentry/utils": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.4.1.tgz",
-      "integrity": "sha512-xJ1uVa5fvg23pXQfulvCIBb9pQ3p1awyd1PapK2AYi+wKjTuYl4B9edmhjRREEQEExznl/d2OVm78fRXLq7M9Q==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.7.2.tgz",
+      "integrity": "sha512-9COL7aaBbe61Hp5BlArtXZ1o/cxli1NGONLPrVT4fMyeQFmLonhUiy77NdsW19XnvhvaA+2IoV5dg3dnFiF/og==",
       "requires": {
-        "@sentry/types": "6.4.1",
+        "@sentry/types": "6.7.2",
         "tslib": "^1.9.3"
       }
     },
@@ -1052,8 +1052,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#66cb40c57968ffbc69dda09a1b709c8a40619069",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v3.3.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#be075a2101518f8b5ef4da0d1ff7e553b05d6da1",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v3.4.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.18.3",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v3.3.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v3.4.0",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "express-session": "^1.15.6",

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -12,3 +12,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USE
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/011-alterfallbackphonenumbertobeanarray.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/012-renameregistrytobuttons.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/013-addapikeytoinstallations.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/014-addrespondedattosessions.sql

--- a/server/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
+++ b/server/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
@@ -1,0 +1,296 @@
+// Third-party dependencies
+const { expect } = require('chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const { ALERT_STATE, ALERT_TYPE, helpers } = require('brave-alert-lib')
+
+// In-house dependencies
+const db = require('../../../db/db.js')
+const SessionState = require('../../../SessionState.js')
+
+describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
+  describe('if there are no installations with the given Alert API Key', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+
+      // Insert a single installation with a single button that has a single session that doesn't match the Alert API Key that we ask for
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', 'alertApiKey')
+      const installationId = (await db.getInstallations())[0].id
+      const buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
+      await db.createButton(buttonId, installationId, 'unit', 'phoneNumber', 'serialNumber')
+      await db.createSession(installationId, buttonId, 'unit', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+    })
+
+    afterEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+    })
+
+    it('should return an empty array', async () => {
+      const rows = await db.getHistoricAlertsByAlertApiKey('not alertApiKey', 10, 50000)
+
+      expect(rows).to.eql([])
+    })
+  })
+
+  describe('if there are no sessions for the installation with the given Alert API Key', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+
+      // Insert a single installation with a single button that has a single session that doesn't match the Alert API Key that we ask for
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', 'not our API key')
+      const installationId = (await db.getInstallations())[0].id
+      const buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
+      await db.createButton(buttonId, installationId, 'unit', 'phoneNumber', 'serialNumber')
+      await db.createSession(installationId, buttonId, 'unit', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+
+      // Insert a single installation with no sessions that matches the Alert API Key that we ask for
+      this.alertApiKey = 'alertApiKey'
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey)
+    })
+
+    afterEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+    })
+
+    it('should return an empty array', async () => {
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 10, 50000)
+
+      expect(rows).to.eql([])
+    })
+  })
+
+  describe('if there is one matching session', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+
+      // Insert a single installation with a single button
+      this.alertApiKey = 'alertApiKey'
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey)
+      this.installationId = (await db.getInstallations())[0].id
+      this.buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
+      this.unit = 'unit1'
+      await db.createButton(this.buttonId, this.installationId, this.unit, 'phoneNumber1', 'serialNumber1')
+
+      // Insert a single session for that API key
+      this.incidentType = ALERT_TYPE.BUTTONS_URGENT
+      this.numPresses = 6
+      this.respondedAt = new Date('2021-01-20T06:20:19.000Z')
+      this.session = await db.createSession(this.installationId, this.buttonId, this.unit, 'phoneNumber', this.numPresses, 95, this.respondedAt)
+      await db.saveSession(
+        new SessionState(
+          this.session.id,
+          this.session.installationId,
+          this.session.buttonId,
+          this.session.unit,
+          this.session.phoneNumber,
+          ALERT_STATE.WAITING_FOR_DETAILS,
+          this.numPresses,
+          this.session.createdAt,
+          new Date(),
+          this.incidentType,
+          '',
+          '',
+          this.session.buttonBatteryLevel,
+          this.respondedAt,
+        ),
+      )
+    })
+
+    afterEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+    })
+
+    it('should return an array with one object with the correct values in it', async () => {
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 1, 1)
+
+      expect(rows).to.eql([
+        {
+          id: this.session.id,
+          unit: this.unit,
+          incident_type: this.incidentType,
+          num_presses: this.numPresses,
+          created_at: this.session.createdAt,
+          responded_at: this.respondedAt,
+        },
+      ])
+    })
+  })
+
+  describe('if there are more matching sessions than maxHistoricAlerts', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+
+      // Insert a single installation with a two buttons and more than maxHistoricAlerts sessions
+      this.alertApiKey = 'alertApiKey'
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey)
+      const installationId = (await db.getInstallations())[0].id
+      const buttonId1 = '51b8be5678bf5ade9bf6a5958b2a4a45'
+      await db.createButton(buttonId1, installationId, 'unit1', 'phoneNumber1', 'serialNumber1')
+      const buttonId2 = '1283be5678bf5ade9bf6a5958b2a4a45'
+      await db.createButton(buttonId2, installationId, 'unit2', 'phoneNumber2', 'serialNumber2')
+      this.session1 = await db.createSession(installationId, buttonId1, 'unit1', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+      this.session2 = await db.createSession(installationId, buttonId2, 'unit2', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+      this.session3 = await db.createSession(installationId, buttonId2, 'unit2', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+      this.session4 = await db.createSession(installationId, buttonId1, 'unit1', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+      this.session5 = await db.createSession(installationId, buttonId2, 'unit2', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+    })
+
+    afterEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+    })
+
+    it('should return only the most recent maxHistoricAlerts of them', async () => {
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 3, 1)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([this.session5.id, this.session4.id, this.session3.id])
+    })
+  })
+
+  describe('if there are fewer matching sessions than maxHistoricAlerts', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+
+      // Insert a single installation with a two buttons and maxHistoricAlerts sessions
+      this.alertApiKey = 'alertApiKey'
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey)
+      const installationId = (await db.getInstallations())[0].id
+      const buttonId1 = '51b8be5678bf5ade9bf6a5958b2a4a45'
+      await db.createButton(buttonId1, installationId, 'unit1', 'phoneNumber1', 'serialNumber1')
+      const buttonId2 = '1283be5678bf5ade9bf6a5958b2a4a45'
+      await db.createButton(buttonId2, installationId, 'unit2', 'phoneNumber2', 'serialNumber2')
+      this.session1 = await db.createSession(installationId, buttonId1, 'unit1', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+      this.session2 = await db.createSession(installationId, buttonId2, 'unit2', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+      await helpers.sleep(2000) // Couldn't get around doing this because there is a trigger on updated_at to keep it correct
+      this.session3 = await db.createSession(installationId, buttonId2, 'unit2', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+      this.session4 = await db.createSession(installationId, buttonId1, 'unit1', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+      this.session5 = await db.createSession(installationId, buttonId2, 'unit2', 'phoneNumber', 5, 95, new Date('2021-01-20T06:20:19.000Z'))
+    })
+
+    afterEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+    })
+
+    it('should return only the matches', async () => {
+      // maxTimeAgoInMillis should give me a time during the sleep in the test
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 5, 1000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([this.session2.id, this.session1.id])
+    })
+  })
+
+  describe('if is a session more recent than maxTimeAgoInMillis', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+
+      // Insert a single installation with a one button and one session
+      this.alertApiKey = 'alertApiKey'
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey)
+      const installationId = (await db.getInstallations())[0].id
+      const buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
+      const unit = 'unit1'
+      await db.createButton(buttonId, installationId, unit, 'phoneNumber1', 'serialNumber1')
+      this.session = await db.createSession(installationId, buttonId, unit, 'phoneNumber', '1', 95, new Date('2021-01-20T06:20:19.000Z'))
+    })
+
+    afterEach(async () => {
+      await db.clearSessions()
+      await db.clearButtons()
+      await db.clearInstallations()
+    })
+
+    it('and it is COMPLETED, should return the Completed session', async () => {
+      // Update the session to COMPLETED
+      const updatedSession = { ...this.session }
+      updatedSession.state = ALERT_STATE.COMPLETED
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 1, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([this.session.id])
+    })
+
+    it('and it is WAITING_FOR_DETAILS, should not return it', async () => {
+      // Update the session to WAITING_FOR_DETAILS
+      const updatedSession = { ...this.session }
+      updatedSession.state = ALERT_STATE.WAITING_FOR_DETAILS
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 1, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+
+    it('and it is WAITING_FOR_CATEGORY, should not return it', async () => {
+      // Update the session to WAITING_FOR_CATEGORY
+      const updatedSession = { ...this.session }
+      updatedSession.state = ALERT_STATE.WAITING_FOR_CATEGORY
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 1, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+
+    it('and it is WAITING_FOR_REPLY, should not return it', async () => {
+      // Update the session to WAITING_FOR_REPLY
+      const updatedSession = { ...this.session }
+      updatedSession.state = ALERT_STATE.WAITING_FOR_REPLY
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 1, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+
+    it('and it is STARTED, should not return it', async () => {
+      // Update the session to STARTED
+      const updatedSession = { ...this.session }
+      updatedSession.state = ALERT_STATE.STARTED
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 1, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+  })
+})

--- a/server/test/integration/serverTest.js
+++ b/server/test/integration/serverTest.js
@@ -52,8 +52,8 @@ describe('Chatbot server', () => {
 
   describe('POST request: flic button press', () => {
     beforeEach(async () => {
-      sinon.stub(helpers, 'log')
-      sinon.stub(helpers, 'logError')
+      sinon.spy(helpers, 'log')
+      sinon.spy(helpers, 'logError')
 
       await db.clearSessions()
       await db.clearButtons()

--- a/server/test/testingHelpers.js
+++ b/server/test/testingHelpers.js
@@ -15,6 +15,7 @@ function createTestSessionState() {
     'fakeNotes',
     'fakeFallbackTwilioState',
     null,
+    new Date('2000-06-06T00:53:53.000Z'),
   )
 }
 

--- a/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
@@ -14,6 +14,8 @@ use(sinonChai)
 
 describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', () => {
   beforeEach(() => {
+    this.fakeCurrentTime = new Date('2020-12-25T10:09:08.000Z')
+    sinon.stub(db, 'getCurrentTime').returns(this.fakeCurrentTime)
     sinon.stub(db, 'beginTransaction')
     sinon.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
     sinon.stub(db, 'getInstallationWithSessionId').returns({
@@ -29,15 +31,66 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     db.getInstallationWithSessionId.restore()
     db.getSessionWithSessionId.restore()
     db.beginTransaction.restore()
+    db.getCurrentTime.restore()
   })
 
-  it('if given only alertState should update only alertState', async () => {
+  it('if given alertState STARTED should update only alertState', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-    await braveAlerter.alertSessionChangedCallback(new AlertSession(this.fakeSessionId, ALERT_STATE.WAITING_FOR_REPLY))
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.STARTED))
+
+    const expectedSession = createTestSessionState()
+    expectedSession.state = ALERT_STATE.STARTED
+
+    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+  })
+
+  it('if given alertState WAITING_FOR_REPLY should update only alertState', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.WAITING_FOR_REPLY))
 
     const expectedSession = createTestSessionState()
     expectedSession.state = ALERT_STATE.WAITING_FOR_REPLY
+
+    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+  })
+
+  it('if given alertState WAITING_FOR_CATEGORY should update alertState and respondedAt', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.WAITING_FOR_CATEGORY))
+
+    const expectedSession = createTestSessionState()
+    expectedSession.state = ALERT_STATE.WAITING_FOR_CATEGORY
+    expectedSession.respondedAt = this.fakeCurrentTime
+
+    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+  })
+
+  it('if given alertState WAITING_FOR_DETAILS should update only alertState', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.WAITING_FOR_DETAILS))
+
+    const expectedSession = createTestSessionState()
+    expectedSession.state = ALERT_STATE.WAITING_FOR_DETAILS
+
+    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+  })
+
+  it('if given alertState COMPLETED should update only alertState', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.COMPLETED))
+
+    const expectedSession = createTestSessionState()
+    expectedSession.state = ALERT_STATE.COMPLETED
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
   })

--- a/server/test/unit/BraveAlerterConfiguratorTest/getHistoricAlertsByAlertApiKeyTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/getHistoricAlertsByAlertApiKeyTest.js
@@ -1,0 +1,148 @@
+// Third-party dependencies
+const { expect, use } = require('chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+
+const { helpers, HistoricAlert, ALERT_TYPE } = require('brave-alert-lib')
+const db = require('../../../db/db.js')
+const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator.js')
+
+// Configure Chai
+use(sinonChai)
+
+describe('BraveAlerterConfigurator.js unit tests: getHistoricAlertsByAlertApiKey and createHistoricAlertFromRow', () => {
+  beforeEach(() => {
+    this.maxTimeAgoInMillis = 60000
+    sinon.stub(helpers, 'getEnvVar').returns(this.maxTimeAgoInMillis)
+
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    this.braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+  })
+
+  afterEach(() => {
+    helpers.getEnvVar.restore()
+    db.getHistoricAlertsByAlertApiKey.restore()
+  })
+
+  it('if there is a single result from db.getHistoricAlertsByAlertApiKey with num_presses > 1, returns an array containing a single HistoricAlert object with the returned data and ALERT_TYPE.BUTTONS_URGENT', async () => {
+    const results = {
+      id: 'id',
+      unit: 'unit',
+      incident_type: 'incidentType',
+      num_presses: 2,
+      created_at: new Date('2020-01-20T10:10:10.000Z'),
+      responded_at: new Date('2020-01-20T10:12:40.000Z'),
+    }
+    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns([results])
+
+    const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
+
+    expect(historicAlerts).to.eql([
+      new HistoricAlert(
+        results.id,
+        results.unit,
+        results.incident_type,
+        ALERT_TYPE.BUTTONS_URGENT,
+        results.num_presses,
+        results.created_at,
+        results.responded_at,
+      ),
+    ])
+  })
+
+  it('if there is a single result from db.getHistoricAlertsByAlertApiKey with num_presses = 1, returns an array containing a single HistoricAlert object with the returned data and ALERT_TYPE.BUTTONS_NOT_URGENT', async () => {
+    const results = {
+      id: 'id',
+      unit: 'unit',
+      incident_type: 'incidentType',
+      num_presses: 1,
+      created_at: new Date('2020-01-20T10:10:10.000Z'),
+      responded_at: new Date('2020-01-20T10:12:40.000Z'),
+    }
+    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns([results])
+
+    const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
+
+    expect(historicAlerts).to.eql([
+      new HistoricAlert(
+        results.id,
+        results.unit,
+        results.incident_type,
+        ALERT_TYPE.BUTTONS_NOT_URGENT,
+        results.num_presses,
+        results.created_at,
+        results.responded_at,
+      ),
+    ])
+  })
+
+  it('if there are multiple results from db.getHistoricAlertsByAlertApiKey, returns an array containing the HistoricAlert objects with the returned data', async () => {
+    const results1 = {
+      id: 'id1',
+      unit: 'unit1',
+      incident_type: 'incidentType1',
+      num_presses: 1,
+      created_at: new Date('2020-01-20T10:10:10.000Z'),
+      responded_at: new Date('2020-01-20T10:12:40.000Z'),
+    }
+    const results2 = {
+      id: 'id2',
+      unit: 'unit2',
+      incident_type: 'incidentType2',
+      num_presses: 2,
+      created_at: new Date('2019-02-20T09:10:10.000Z'),
+      responded_at: new Date('2019-02-20T09:12:40.000Z'),
+    }
+    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns([results1, results2])
+
+    const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
+
+    expect(historicAlerts).to.eql([
+      new HistoricAlert(
+        results1.id,
+        results1.unit,
+        results1.incident_type,
+        ALERT_TYPE.BUTTONS_NOT_URGENT,
+        results1.num_presses,
+        results1.created_at,
+        results1.responded_at,
+      ),
+      new HistoricAlert(
+        results2.id,
+        results2.unit,
+        results2.incident_type,
+        ALERT_TYPE.BUTTONS_URGENT,
+        results2.num_presses,
+        results2.created_at,
+        results2.responded_at,
+      ),
+    ])
+  })
+
+  it('if there no results from db.getHistoricAlertsByAlertApiKey, returns an empty array', async () => {
+    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns([])
+
+    const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
+
+    expect(historicAlerts).to.eql([])
+  })
+
+  it('if db.getHistoricAlertsByAlertApiKey returns a non-array, returns null', async () => {
+    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns()
+
+    const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
+
+    expect(historicAlerts).to.be.null
+  })
+
+  it('db.getHistoricAlertsByAlertApiKey is called with the given alertApiKey, the given maxHistoricAlerts, and the SESSION_RESET_TIMEOUT from .env', async () => {
+    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns()
+
+    const alertApiKey = 'alertApiKey'
+    const maxHistoricAlerts = 'maxHistoricAlerts'
+    await this.braveAlerter.getHistoricAlertsByAlertApiKey(alertApiKey, maxHistoricAlerts)
+
+    expect(db.getHistoricAlertsByAlertApiKey).to.be.calledWith(alertApiKey, maxHistoricAlerts, this.maxTimeAgoInMillis)
+  })
+})

--- a/server/test/unit/dbTest.js
+++ b/server/test/unit/dbTest.js
@@ -16,7 +16,7 @@ describe('DB', () => {
     describe('when not given a client', () => {
       describe('if an error is thrown while trying to get a DB client from the pool', () => {
         beforeEach(() => {
-          sinon.stub(helpers, 'logError')
+          sinon.spy(helpers, 'logError')
           this.pool = db.getPool()
           sinon.stub(this.pool, 'connect').rejects
         })
@@ -49,7 +49,7 @@ describe('DB', () => {
 
       describe('if an error is thrown during a database query', () => {
         beforeEach(() => {
-          sinon.stub(helpers, 'logError')
+          sinon.spy(helpers, 'logError')
           this.client = {
             query: sinon.stub().rejects,
             release: sinon.stub(),
@@ -86,7 +86,7 @@ describe('DB', () => {
 
       describe('if there is one unresponded session with the given buttonId', () => {
         beforeEach(() => {
-          sinon.stub(helpers, 'log')
+          sinon.spy(helpers, 'log')
           this.client = {
             query: sinon.stub().resolves({
               rows: [
@@ -104,6 +104,7 @@ describe('DB', () => {
                   notes: 'fakeNotes',
                   fallback_alert_twilio_status: 'fakeFallbackTwilioState',
                   button_battery_level: null,
+                  responded_at: new Date('2000-06-06T00:53:53.000Z'),
                 },
               ],
             }),
@@ -141,7 +142,7 @@ describe('DB', () => {
   describe('when given a client', () => {
     describe('if an error is thrown during a database query', () => {
       beforeEach(() => {
-        sinon.stub(helpers, 'logError')
+        sinon.spy(helpers, 'logError')
 
         this.pool = db.getPool()
         sinon.stub(this.pool, 'connect')
@@ -185,7 +186,7 @@ describe('DB', () => {
 
     describe('if there is one unresponded session with the given buttonId', () => {
       beforeEach(() => {
-        sinon.stub(helpers, 'log')
+        sinon.spy(helpers, 'log')
         this.client = {
           query: sinon.stub().resolves({
             rows: [
@@ -203,6 +204,7 @@ describe('DB', () => {
                 notes: 'fakeNotes',
                 fallback_alert_twilio_status: 'fakeFallbackTwilioState',
                 button_battery_level: null,
+                responded_at: new Date('2000-06-06T00:53:53.000Z'),
               },
             ],
           }),


### PR DESCRIPTION
- To be used by the Alert App
- Added `responded_at` column to the `sessions` table because this
  needs to be returned by the new endpoint
- Added functionality to set the `session.responded_at` column at
  the appropriate times
- Added "Responded At" column to the Chatbot Dashboard
- Moved `SESSION_RESET_TIMEOUT` into the .env so that it would
  be easily accessible from `BraveAlerterConfigurator.js` without
  needing to pass it in to the constructor. This is also good for
  manual testing because waiting 2 hours can suck. So it'll be good
  to be able to just change the .env and redeploy to wait for a
  shorter period of time to test this functionality
- Added and changed tests accordingly
- Changed all sinon.stub(helpers, 'log*') calls to use sinon.spy
  instead so that I could still see the log output in the console
  while the spy tracks when and with what parameters it is called

Corresponding brave-alert-lib PR: https://github.com/bravetechnologycoop/brave-alert-lib/pull/15

**Test plan:**
- :heavy_check_mark: Deploy Buttons to `chatbot-dev` and go through all the flows with a real Button watching when and if the `responded_at` value changed
- :heavy_check_mark: Hit `GET https://chatbot-dev.brave.coop/alert/historicAlerts` for my test Button and see that
   - :heavy_check_mark: Not-completed Button presses in the last 2 hours are not returned
   - :heavy_check_mark: Completed Button presses in the last 2 hours are returned
   - :heavy_check_mark: All Button presses longer ago than 2 hours are returned
   - :heavy_check_mark: Different values for `X-API-KEY` (missing, empty string, no matching API key, matching API key)
   - :heavy_check_mark: Different values for `maxHistoricAlerts` (missing, null, empty string, 0, -1, 1, 99999)
   - :heavy_check_mark: Sessions that return HistoricAlerts where `alertType` is either `BUTTON_URGENT` or `BUTTONS_NOT_URGENT` depending on the value of `numPresses`
   - :heavy_check_mark: HistoricAlerts which are returned have the values I'd expect based on the Sessions they were created from
- :heavy_check_mark: Hit the `GET https://chatbot-dev.brave.coop/alert/historicAlerts` endpoint from the Alert App and render its results
- :heavy_check_mark: Look at Chatbot Dashboard to see the new Responded At column and that it has the right value in it
- :heavy_check_mark: Change `SESSION_RESET_TIMEOUT` and see it work as expected for new Button presses and for determining what is a Historic Alert