### PR TITLE
Add VSCode launch config for debugging Mocha tests for /server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    // Mocha configs from https://medium.com/guidesmiths-dev/how-to-configure-visual-studio-code-for-test-debugging-39d0d7f24d79
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha All within 'server/test' folder",
+      "program": "${workspaceFolder}/server/node_modules/mocha/bin/_mocha",
+      "args": ["--timeout", "999999", "--colors", "${workspaceFolder}/server/test/**/*"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "envFile": "${workspaceFolder}/server/.env",
+      "env": { "NODE_ENV": "test" }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Current File in /server",
+      "program": "${workspaceFolder}/server/node_modules/mocha/bin/_mocha",
+      "args": ["--timeout", "999999", "--colors", "${file}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "envFile": "${workspaceFolder}/server/.env",
+      "env": { "NODE_ENV": "test" }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## Unreleased
 
+### Added
+
+- Mocha debugging configuration for `/server`.
+
 ## [4.0.0] - 2021-06-15
 
 ### Changed


### PR DESCRIPTION
- So that those of us who use VS Code will be able to use it to
  debug Mocha tests without any extra work

Some screenshots of how it works from the equivalent change in BraveSensors: https://github.com/bravetechnologycoop/BraveSensor-Server/pull/114/files