### PR TITLE
Fix time formatting in CSV Export (CU-zkkach)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ the code was deployed.
 
 - Updated deployment instructions (CU-wb8719).
 
+### Fixed
+
+- Time strings in CSV Export now have the correct hour and minute values (CU-zkkach).
+
 ## [4.0.0] - 2021-06-15
 
 ### Changed

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -898,7 +898,31 @@ async function getDataForExport(clientParam) {
     }
 
     const { rows } = await client.query(
-      `SELECT i.name AS "Installation Name", i.responder_phone_number AS "Responder Phone", i.fall_back_phone_numbers AS "Fallback Phones", TO_CHAR(i.created_at, 'yyyy-MM-dd HH:mm:ss') AS "Date Installation Created", i.incident_categories AS "Incident Categories", i.is_active AS "Active?", s.unit AS "Unit", s.phone_number AS "Button Phone", s.state AS "Session State", s.num_presses AS "Number of Presses", TO_CHAR(s.created_at, 'yyyy-MM-dd HH:mm:ss') AS "Session Start", TO_CHAR(s.updated_at, 'yyyy-MM-dd HH:mm:ss') AS "Last Session Activity", s.incident_type AS "Session Incident Type", s.notes as "Session Notes", s.fallback_alert_twilio_status AS "Fallback Alert Status (Twilio)", s.button_battery_level AS "Button Battery Level", TO_CHAR(r.created_at, 'yyyy-MM-dd HH:mm:ss') AS "Date Button Created", TO_CHAR(r.updated_at, 'yyyy-MM-dd HH:mm:ss') AS "Button Last Updated", r.button_serial_number AS "Button Serial Number" FROM sessions s JOIN buttons r ON s.button_id = r.button_id JOIN installations i ON i.id = s.installation_id`,
+      `
+      SELECT
+        i.name AS "Installation Name",
+        i.responder_phone_number AS "Responder Phone",
+        i.fall_back_phone_numbers AS "Fallback Phones",
+        TO_CHAR(i.created_at, 'yyyy-MM-dd HH24:mi:ss') AS "Date Installation Created",
+        i.incident_categories AS "Incident Categories",
+        i.is_active AS "Active?",
+        s.unit AS "Unit",
+        s.phone_number AS "Button Phone",
+        s.state AS "Session State",
+        s.num_presses AS "Number of Presses",
+        TO_CHAR(s.created_at, 'yyyy-MM-dd HH24:mi:ss') AS "Session Start",
+        TO_CHAR(s.updated_at, 'yyyy-MM-dd HH24:mi:ss') AS "Last Session Activity",
+        s.incident_type AS "Session Incident Type",
+        s.notes as "Session Notes",
+        s.fallback_alert_twilio_status AS "Fallback Alert Status (Twilio)",
+        s.button_battery_level AS "Button Battery Level",
+        TO_CHAR(r.created_at, 'yyyy-MM-dd HH24:mi:ss') AS "Date Button Created",
+        TO_CHAR(r.updated_at, 'yyyy-MM-dd HH24:mi:ss') AS "Button Last Updated",
+        r.button_serial_number AS "Button Serial Number"
+      FROM sessions s
+        JOIN buttons r ON s.button_id = r.button_id
+        JOIN installations i ON i.id = s.installation_id
+      `,
     )
 
     return rows


### PR DESCRIPTION
- Postgres doesn't use the standard date/time format string that is
  used in programming languages. Instead, "HH" means 12-hour hours
  when what we wanted was "HH24" to get 24-hour hours and "MM" means
  months when what we wanted was "MI" to get minutes

Test Plan:
- :heavy_check_mark:  Deploy to `chatbot-dev`, export the CSV, check all 5 date/time columns against the values in the DB and make sure that they are right even when the hour is > 12 and the minute is different than the month's number.