### PR TITLE
added audit-ci to Travis to check for security issues in server deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,9 @@ matrix:
       before_script:
         - bash setup_postgresql_local_dev.sh
 
-      # run linter and unit tests
+      # run security audit, linter and unit tests
       script:
+        - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npx audit-ci --config ./audit-ci.json; fi
         - npm run lint
         - sudo env "PATH=$PATH" npm run test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ the code was deployed.
 - Mocha debugging configuration for `/server`.
 - `GET /alert/historicAlerts` endpoint (CU-hjwfx2).
 - Tracking of when sessions are first responded to (CU-hjwfx2).
+- Security audit to Travis.
 
 ## [4.0.0] - 2021-06-15
 

--- a/server/audit-ci.json
+++ b/server/audit-ci.json
@@ -1,0 +1,5 @@
+{
+  "high": true,
+  "allowlist": [
+  ]
+}


### PR DESCRIPTION
This pull request adds the same `audit-ci` tool to Travis as I added in this BraveAlert pull request: https://github.com/bravetechnologycoop/brave-alert-app/pull/11