### PR TITLE
[DO NOT MERGE] Add daily restart to Pi setup (CU-yzf44q)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ the code was deployed.
 - `GET /alert/historicAlerts` endpoint (CU-hjwfx2).
 - Tracking of when sessions are first responded to (CU-hjwfx2).
 - Security audit to Travis.
+- Daily automatic restart of our Raspberry Pis (CU-yzf44q).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
 
 1. cd into the `BraveButtons/pi` directory
 
-1. copy `template.pi_config.ini` to `pi_config.ini` and fill out variables appropriately for your local environment
+1. copy `example.pi_config.ini` to `pi_config.ini` and fill out variables appropriately for your local environment
 
 1. run `sudo ./setup_pi.sh pi_config.ini`
 

--- a/pi/setup_pi.sh
+++ b/pi/setup_pi.sh
@@ -135,5 +135,10 @@ else
   systemctl enable darkstat
   systemctl enable dhcp-helper
 
+  # restart Pi daily to reduce the number of manual restarts we need to do
+  echo "
+  0 20 * * * /sbin/shutdown -r now
+  " | crontab -
+
   echo "setup complete - please reboot the RPi."
 fi


### PR DESCRIPTION
- We hope that this will reduce the number of times that we need to
  do manual restarts
- Scheduled it for 19:00 UTC (around noon Pacific) because we felt it
  was safer for this downtime to happen in the middle of the day when
  end users may have other means of getting help rather than in the
  middle of the day when they are possibly at their most vulnerable

# Test Plan:
- :heavy_check_mark: Check that it works as expected on my local Pi by:
   1. :heavy_check_mark: Copy `setup_pi.sh` to `/home/pi/BraveButtons/pi` on my Raspberry Pi at home
   1. :heavy_check_mark: From `/home/pi`, run `sudo ./BraveButtons/pi/setup_pi.sh ./BraveButtons/pi/pi_config.ini >> /var/log/brave/ansible-update.log 2>&1`
   1. :heavy_check_mark: Run `shutdown -r now` to reboot the Pi
   1. :heavy_check_mark: Verify that the cronjob is there using `sudo crontab -e`
   1. :heavy_check_mark: Re-run the setup script and check that the cronjob is still there and that it hasn't been duplicated
   1. :heavy_check_mark: Check that it restarts at the given time using `uptime` ([ref](https://www.raspberrypi.org/forums/viewtopic.php?t=148634#p980037))
- :heavy_check_mark: Assuming that it worked as expected on my local, then SSH into the following production Pis and do the same thing:
   - :heavy_check_mark: Buchan Hub 2
   - :heavy_check_mark: Viv Pi 2
   - :heavy_check_mark: Viv Pi 3
   - :heavy_check_mark: Viv Pi 1
   - :heavy_check_mark: Kye7e
   - :heavy_check_mark: Alvis Hub 4