### PR TITLE
POST /flic_button_press returns 401 when given invalid API Key (CU-gwxnde)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ the code was deployed.
 ### Changed
 
 - Updated deployment instructions (CU-wb8719).
+- `POST /flic_button_press` returns 401 Unauthorized when given an invalid API key (CU-gwxnde).
 
 ### Fixed
 

--- a/server/server.js
+++ b/server/server.js
@@ -314,11 +314,10 @@ app.post('/flic_button_press', Validator.header(['button-serial-number']).exists
       const apiKey = req.query.apikey
 
       // Log the vaiditiy of the API key
-      // TODO (CU-gwxnde) Replace this with a 401 unauthorized if invalid
       if (apiKey !== helpers.getEnvVar('FLIC_BUTTON_PRESS_API_KEY')) {
         helpers.logError(`INVALID api key from '${buttonName}' (${serialNumber})`)
-      } else {
-        helpers.log(`VALID api key from '${buttonName}' (${serialNumber})`)
+        res.status(401).send()
+        return
       }
 
       const button = await db.getButtonWithSerialNumber(serialNumber)


### PR DESCRIPTION
- This makes it more difficult for people to hit our endpoint
  pretending to be a Button when really they aren't.
- Gives us better security against this attack
- Also made the formatting and prettier-ignores more consistent in `serverTest.js`

## Test Plan
- :heavy_check_mark: Check that there have been no `INVALID` logs in production in all the logs that we have right now (right now, this covers July 6-20)
- :heavy_check_mark: Deploy to chatbot-dev
- :heavy_check_mark: Configure my real buttons to hit `POST /flic_button_press` with the real API key
   - :heavy_check_mark: Starts chatbot session
- :heavy_check_mark: Configure my real buttons to hit `POST /flic_button_press` with an invalid API key
   - :heavy_check_mark: Doesn't starts chatbot session
   - :heavy_check_mark: Logs the invalid API attempt
- :heavy_check_mark: Configure my real buttons to hit `POST /flic_button_press` with no API key
   - :heavy_check_mark: Doesn't starts chatbot session
   - :heavy_check_mark: Logs the invalid API attempt
- :heavy_check_mark: Use Postman to hit `POST /flic_button_press` with an invalid API key and with no API key to see that it returns 401