### PR TITLE
Change `ALERT_STATE` to `CHATBOT_STATE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## Unreleased
 
+### Changed
+
+- Updated `ALERT_STATE` to `CHATBOT_STATE`.
+
 ## [4.1.0] - 2021-07-26
 
 ### Added

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-const { BraveAlerter, AlertSession, ALERT_TYPE, ALERT_STATE, helpers, Location, SYSTEM, HistoricAlert } = require('brave-alert-lib')
+const { BraveAlerter, AlertSession, ALERT_TYPE, CHATBOT_STATE, helpers, Location, SYSTEM, HistoricAlert } = require('brave-alert-lib')
 const db = require('./db/db.js')
 
 class BraveAlerterConfigurator {
@@ -105,7 +105,7 @@ class BraveAlerterConfigurator {
           session.fallBackAlertTwilioStatus = alertSession.fallbackReturnMessage
         }
 
-        if (alertSession.alertState === ALERT_STATE.WAITING_FOR_CATEGORY) {
+        if (alertSession.alertState === CHATBOT_STATE.WAITING_FOR_CATEGORY) {
           session.respondedAt = await db.getCurrentTime(client)
         }
 
@@ -163,24 +163,24 @@ class BraveAlerterConfigurator {
     let returnMessage
 
     switch (fromAlertState) {
-      case ALERT_STATE.STARTED:
-      case ALERT_STATE.WAITING_FOR_REPLY:
+      case CHATBOT_STATE.STARTED:
+      case CHATBOT_STATE.WAITING_FOR_REPLY:
         returnMessage = this.createResponseStringFromIncidentCategories(incidentCategories)
         break
 
-      case ALERT_STATE.WAITING_FOR_CATEGORY:
-        if (toAlertState === ALERT_STATE.WAITING_FOR_CATEGORY) {
+      case CHATBOT_STATE.WAITING_FOR_CATEGORY:
+        if (toAlertState === CHATBOT_STATE.WAITING_FOR_CATEGORY) {
           returnMessage = "Sorry, the incident type wasn't recognized. Please try again."
-        } else if (toAlertState === ALERT_STATE.WAITING_FOR_DETAILS) {
+        } else if (toAlertState === CHATBOT_STATE.WAITING_FOR_DETAILS) {
           returnMessage = 'Thank you. If you like, you can reply with any further details about the incident.'
         }
         break
 
-      case ALERT_STATE.WAITING_FOR_DETAILS:
+      case CHATBOT_STATE.WAITING_FOR_DETAILS:
         returnMessage = "Thank you. This session is now complete. (You don't need to respond to this message.)"
         break
 
-      case ALERT_STATE.COMPLETED:
+      case CHATBOT_STATE.COMPLETED:
         returnMessage = "There is no active session for this button. (You don't need to respond to this message.)"
         break
 

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1,4 +1,4 @@
-const { ALERT_STATE, helpers } = require('brave-alert-lib')
+const { CHATBOT_STATE, helpers } = require('brave-alert-lib')
 const { Pool, types } = require('pg')
 
 const Hub = require('../Hub.js')
@@ -98,7 +98,7 @@ async function getUnrespondedSessionWithButtonId(buttonId, clientParam) {
     }
 
     const query = 'SELECT * FROM sessions WHERE button_id = $1 AND state != $2 AND state != $3 AND state != $4 ORDER BY created_at DESC LIMIT 1'
-    const values = [buttonId, ALERT_STATE.WAITING_FOR_CATEGORY, ALERT_STATE.WAITING_FOR_DETAILS, ALERT_STATE.COMPLETED]
+    const values = [buttonId, CHATBOT_STATE.WAITING_FOR_CATEGORY, CHATBOT_STATE.WAITING_FOR_DETAILS, CHATBOT_STATE.COMPLETED]
     const { rows } = await client.query(query, values)
 
     if (rows.length > 0) {
@@ -129,7 +129,7 @@ async function getMostRecentIncompleteSessionWithPhoneNumber(phoneNumber, client
     }
 
     const query = 'SELECT * FROM sessions WHERE phone_number = $1 AND state != $2 ORDER BY created_at DESC LIMIT 1'
-    const values = [phoneNumber, ALERT_STATE.COMPLETED]
+    const values = [phoneNumber, CHATBOT_STATE.COMPLETED]
     const { rows } = await client.query(query, values)
 
     if (rows.length > 0) {
@@ -273,7 +273,7 @@ async function createSession(installationId, buttonId, unit, phoneNumber, numPre
       client = await pool.connect()
     }
 
-    const values = [installationId, buttonId, unit, phoneNumber, ALERT_STATE.STARTED, numPresses, buttonBatteryLevel, respondedAt]
+    const values = [installationId, buttonId, unit, phoneNumber, CHATBOT_STATE.STARTED, numPresses, buttonBatteryLevel, respondedAt]
     const { rows } = await client.query(
       'INSERT INTO sessions (installation_id, button_id, unit, phone_number, state, num_presses, button_battery_level, responded_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *',
       values,
@@ -661,7 +661,7 @@ async function getHistoricAlertsByAlertApiKey(alertApiKey, maxHistoricAlerts, ma
       ORDER BY s.created_at DESC
       LIMIT $4
       `,
-      [alertApiKey, ALERT_STATE.COMPLETED, maxTimeAgoInMillis, maxHistoricAlerts],
+      [alertApiKey, CHATBOT_STATE.COMPLETED, maxTimeAgoInMillis, maxHistoricAlerts],
     )
 
     return rows

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -524,47 +524,47 @@
       "dev": true
     },
     "@sentry/core": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.8.0.tgz",
-      "integrity": "sha512-vJzWt/znEB+JqVwtwfjkRrAYRN+ep+l070Ti8GhJnvwU4IDtVlV3T/jVNrj6rl6UChcczaJQMxVxtG5x0crlAA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.10.0.tgz",
+      "integrity": "sha512-5KlxHJlbD7AMo+b9pMGkjxUOfMILtsqCtGgI7DMvZNfEkdohO8QgUY+hPqr540kmwArFS91ipQYWhqzGaOhM3Q==",
       "requires": {
-        "@sentry/hub": "6.8.0",
-        "@sentry/minimal": "6.8.0",
-        "@sentry/types": "6.8.0",
-        "@sentry/utils": "6.8.0",
+        "@sentry/hub": "6.10.0",
+        "@sentry/minimal": "6.10.0",
+        "@sentry/types": "6.10.0",
+        "@sentry/utils": "6.10.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.8.0.tgz",
-      "integrity": "sha512-hFrI2Ss1fTov7CH64FJpigqRxH7YvSnGeqxT9Jc1BL7nzW/vgCK+Oh2mOZbosTcrzoDv+lE8ViOnSN3w/fo+rg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.10.0.tgz",
+      "integrity": "sha512-MV8wjhWiFAXZAhmj7Ef5QdBr2IF93u8xXiIo2J+dRZ7eVa4/ZszoUiDbhUcl/TPxczaw4oW2a6tINBNFLzXiig==",
       "requires": {
-        "@sentry/types": "6.8.0",
-        "@sentry/utils": "6.8.0",
+        "@sentry/types": "6.10.0",
+        "@sentry/utils": "6.10.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.8.0.tgz",
-      "integrity": "sha512-MRxUKXiiYwKjp8mOQMpTpEuIby1Jh3zRTU0cmGZtfsZ38BC1JOle8xlwC4FdtOH+VvjSYnPBMya5lgNHNPUJDQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.10.0.tgz",
+      "integrity": "sha512-yarm046UgUFIBoxqnBan2+BEgaO9KZCrLzsIsmALiQvpfW92K1lHurSawl5W6SR7wCYBnNn7CPvPE/BHFdy4YA==",
       "requires": {
-        "@sentry/hub": "6.8.0",
-        "@sentry/types": "6.8.0",
+        "@sentry/hub": "6.10.0",
+        "@sentry/types": "6.10.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.8.0.tgz",
-      "integrity": "sha512-DPUtDd1rRbDJys+aZdQTScKy2Xxo4m8iSQPxzfwFROsLmzE7XhDoriDwM+l1BpiZYIhxUU2TLxDyVzmdc/TMAw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.10.0.tgz",
+      "integrity": "sha512-buGmOjsTnxebHSfa3r/rhpjDk8xmrILG4xslTgV1C2JpbUtf96QnYNNydfsfAGcZrLWO0gid/wigxsx1fdXT8A==",
       "requires": {
-        "@sentry/core": "6.8.0",
-        "@sentry/hub": "6.8.0",
-        "@sentry/tracing": "6.8.0",
-        "@sentry/types": "6.8.0",
-        "@sentry/utils": "6.8.0",
+        "@sentry/core": "6.10.0",
+        "@sentry/hub": "6.10.0",
+        "@sentry/tracing": "6.10.0",
+        "@sentry/types": "6.10.0",
+        "@sentry/utils": "6.10.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -572,28 +572,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.8.0.tgz",
-      "integrity": "sha512-3gDkQnmOuOjHz5rY7BOatLEUksANU3efR8wuBa2ujsPQvoLSLFuyZpRjPPsxuUHQOqAYIbSNAoDloXECvQeHjw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.10.0.tgz",
+      "integrity": "sha512-jZj6Aaf8kU5wgyNXbAJHosHn8OOFdK14lgwYPb/AIDsY35g9a9ncTOqIOBp8X3KkmSR8lcBzAEyiUzCxAis2jA==",
       "requires": {
-        "@sentry/hub": "6.8.0",
-        "@sentry/minimal": "6.8.0",
-        "@sentry/types": "6.8.0",
-        "@sentry/utils": "6.8.0",
+        "@sentry/hub": "6.10.0",
+        "@sentry/minimal": "6.10.0",
+        "@sentry/types": "6.10.0",
+        "@sentry/utils": "6.10.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.8.0.tgz",
-      "integrity": "sha512-PbSxqlh6Fd5thNU5f8EVYBVvX+G7XdPA+ThNb2QvSK8yv3rIf0McHTyF6sIebgJ38OYN7ZFK7vvhC/RgSAfYTA=="
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.10.0.tgz",
+      "integrity": "sha512-M7s0JFgG7/6/yNVYoPUbxzaXDhnzyIQYRRJJKRaTD77YO4MHvi4Ke8alBWqD5fer0cPIfcSkBqa9BLdqRqcMWw=="
     },
     "@sentry/utils": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.8.0.tgz",
-      "integrity": "sha512-OYlI2JNrcWKMdvYbWNdQwR4QBVv2V0y5wK0U6f53nArv6RsyO5TzwRu5rMVSIZofUUqjoE5hl27jqnR+vpUrsA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.10.0.tgz",
+      "integrity": "sha512-F9OczOcZMFtazYVZ6LfRIe65/eOfQbiAedIKS0li4npuMz0jKYRbxrjd/U7oLiNQkPAp4/BujU4m1ZIwq6a+tg==",
       "requires": {
-        "@sentry/types": "6.8.0",
+        "@sentry/types": "6.10.0",
         "tslib": "^1.9.3"
       }
     },
@@ -1052,8 +1052,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#a672458eb8a7a3eb75120f848aca1afcace675dc",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v3.5.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#5d22132bb4510841553fa50cf0863f7bc98a3c5a",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v4.0.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.18.3",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v3.5.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v4.0.0",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "express-session": "^1.15.6",

--- a/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
@@ -3,13 +3,13 @@ const { expect } = require('chai')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 
 // In-house dependencies
-const { ALERT_STATE, AlertSession } = require('brave-alert-lib')
+const { CHATBOT_STATE, AlertSession } = require('brave-alert-lib')
 const db = require('../../../db/db.js')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator.js')
 
 describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneNumber', () => {
   beforeEach(async () => {
-    this.sessionState = ALERT_STATE.WAITING_FOR_DETAILS
+    this.sessionState = CHATBOT_STATE.WAITING_FOR_DETAILS
     this.sessionIncidentType = '2'
     this.sessionNotes = 'sessionNotes'
     this.sessionToPhoneNumber = '+13335557777'

--- a/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
@@ -3,13 +3,13 @@ const { expect } = require('chai')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 
 // In-house dependencies
-const { ALERT_STATE, AlertSession } = require('brave-alert-lib')
+const { CHATBOT_STATE, AlertSession } = require('brave-alert-lib')
 const db = require('../../../db/db.js')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator.js')
 
 describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () => {
   beforeEach(async () => {
-    this.sessionState = ALERT_STATE.WAITING_FOR_DETAILS
+    this.sessionState = CHATBOT_STATE.WAITING_FOR_DETAILS
     this.sessionIncidentType = '2'
     this.sessionNotes = 'sessionNotes'
     this.message = 'message'

--- a/server/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
+++ b/server/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
@@ -1,7 +1,7 @@
 // Third-party dependencies
 const { expect } = require('chai')
 const { afterEach, beforeEach, describe, it } = require('mocha')
-const { ALERT_STATE, ALERT_TYPE, helpers } = require('brave-alert-lib')
+const { CHATBOT_STATE, ALERT_TYPE, helpers } = require('brave-alert-lib')
 
 // In-house dependencies
 const db = require('../../../db/db.js')
@@ -97,7 +97,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
           this.session.buttonId,
           this.session.unit,
           this.session.phoneNumber,
-          ALERT_STATE.WAITING_FOR_DETAILS,
+          CHATBOT_STATE.WAITING_FOR_DETAILS,
           this.numPresses,
           this.session.createdAt,
           new Date(),
@@ -238,7 +238,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
     it('and it is COMPLETED, should return the Completed session', async () => {
       // Update the session to COMPLETED
       const updatedSession = { ...this.session }
-      updatedSession.state = ALERT_STATE.COMPLETED
+      updatedSession.state = CHATBOT_STATE.COMPLETED
       await db.saveSession(updatedSession)
 
       // maxTimeAgoInMillis is much greater than the time this test should take to run
@@ -252,7 +252,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
     it('and it is WAITING_FOR_DETAILS, should not return it', async () => {
       // Update the session to WAITING_FOR_DETAILS
       const updatedSession = { ...this.session }
-      updatedSession.state = ALERT_STATE.WAITING_FOR_DETAILS
+      updatedSession.state = CHATBOT_STATE.WAITING_FOR_DETAILS
       await db.saveSession(updatedSession)
 
       // maxTimeAgoInMillis is much greater than the time this test should take to run
@@ -266,7 +266,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
     it('and it is WAITING_FOR_CATEGORY, should not return it', async () => {
       // Update the session to WAITING_FOR_CATEGORY
       const updatedSession = { ...this.session }
-      updatedSession.state = ALERT_STATE.WAITING_FOR_CATEGORY
+      updatedSession.state = CHATBOT_STATE.WAITING_FOR_CATEGORY
       await db.saveSession(updatedSession)
 
       // maxTimeAgoInMillis is much greater than the time this test should take to run
@@ -280,7 +280,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
     it('and it is WAITING_FOR_REPLY, should not return it', async () => {
       // Update the session to WAITING_FOR_REPLY
       const updatedSession = { ...this.session }
-      updatedSession.state = ALERT_STATE.WAITING_FOR_REPLY
+      updatedSession.state = CHATBOT_STATE.WAITING_FOR_REPLY
       await db.saveSession(updatedSession)
 
       // maxTimeAgoInMillis is much greater than the time this test should take to run
@@ -294,7 +294,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
     it('and it is STARTED, should not return it', async () => {
       // Update the session to STARTED
       const updatedSession = { ...this.session }
-      updatedSession.state = ALERT_STATE.STARTED
+      updatedSession.state = CHATBOT_STATE.STARTED
       await db.saveSession(updatedSession)
 
       // maxTimeAgoInMillis is much greater than the time this test should take to run

--- a/server/test/integration/serverTest.js
+++ b/server/test/integration/serverTest.js
@@ -6,7 +6,7 @@ const { after, afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
 const twilio = require('twilio')
-const { ALERT_STATE, helpers } = require('brave-alert-lib')
+const { CHATBOT_STATE, helpers } = require('brave-alert-lib')
 
 chai.use(chaiHttp)
 chai.use(sinonChai)
@@ -691,7 +691,7 @@ describe('Chatbot server', () => {
 
       let sessions = await db.getAllSessionsWithButtonId(unit1UUID)
       expect(sessions.length).to.equal(1)
-      expect(sessions[0].state, 'state after initial button press').to.deep.equal(ALERT_STATE.STARTED)
+      expect(sessions[0].state, 'state after initial button press').to.deep.equal(CHATBOT_STATE.STARTED)
 
       // prettier-ignore
       let response = await chai
@@ -702,7 +702,7 @@ describe('Chatbot server', () => {
 
       sessions = await db.getAllSessionsWithButtonId(unit1UUID)
       expect(sessions.length).to.equal(1)
-      expect(sessions[0].state, 'state after initial staff response').to.deep.equal(ALERT_STATE.WAITING_FOR_CATEGORY)
+      expect(sessions[0].state, 'state after initial staff response').to.deep.equal(CHATBOT_STATE.WAITING_FOR_CATEGORY)
 
       // prettier-ignore
       response = await chai
@@ -713,7 +713,7 @@ describe('Chatbot server', () => {
 
       sessions = await db.getAllSessionsWithButtonId(unit1UUID)
       expect(sessions.length).to.equal(1)
-      expect(sessions[0].state, 'state after staff have categorized the incident').to.deep.equal(ALERT_STATE.WAITING_FOR_DETAILS)
+      expect(sessions[0].state, 'state after staff have categorized the incident').to.deep.equal(CHATBOT_STATE.WAITING_FOR_DETAILS)
 
       // prettier-ignore
       response = await chai
@@ -724,7 +724,7 @@ describe('Chatbot server', () => {
 
       sessions = await db.getAllSessionsWithButtonId(unit1UUID)
       expect(sessions.length).to.equal(1)
-      expect(sessions[0].state, 'state after staff have provided incident notes').to.deep.equal(ALERT_STATE.COMPLETED)
+      expect(sessions[0].state, 'state after staff have provided incident notes').to.deep.equal(CHATBOT_STATE.COMPLETED)
 
       // now start a new session for a different unit
       // prettier-ignore
@@ -736,7 +736,7 @@ describe('Chatbot server', () => {
 
       sessions = await db.getAllSessionsWithButtonId(unit2UUID)
       expect(sessions.length).to.equal(1)
-      expect(sessions[0].state, 'state after new button press from a different unit').to.deep.equal(ALERT_STATE.STARTED)
+      expect(sessions[0].state, 'state after new button press from a different unit').to.deep.equal(CHATBOT_STATE.STARTED)
       expect(sessions[0].buttonId).to.deep.equal(unit2UUID)
       expect(sessions[0].unit).to.deep.equal('2')
       expect(sessions[0].numPresses).to.deep.equal(1)
@@ -753,7 +753,7 @@ describe('Chatbot server', () => {
       await sleep(4000)
       const sessions = await db.getAllSessionsWithButtonId(unit1UUID)
       expect(sessions.length).to.equal(1)
-      expect(sessions[0].state, 'state after reminder timeout has elapsed').to.deep.equal(ALERT_STATE.WAITING_FOR_REPLY)
+      expect(sessions[0].state, 'state after reminder timeout has elapsed').to.deep.equal(CHATBOT_STATE.WAITING_FOR_REPLY)
       expect(sessions[0].fallBackAlertTwilioStatus).to.not.be.null
       expect(sessions[0].fallBackAlertTwilioStatus).to.not.equal('failed, ')
       expect(sessions[0].fallBackAlertTwilioStatus).to.not.equal('undelivered, ')

--- a/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
@@ -4,7 +4,7 @@ const { afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
 
-const { ALERT_STATE, AlertSession } = require('brave-alert-lib')
+const { CHATBOT_STATE, AlertSession } = require('brave-alert-lib')
 const db = require('../../../db/db.js')
 const { createTestSessionState } = require('../../testingHelpers.js')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator.js')
@@ -38,10 +38,10 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.STARTED))
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.STARTED))
 
     const expectedSession = createTestSessionState()
-    expectedSession.state = ALERT_STATE.STARTED
+    expectedSession.state = CHATBOT_STATE.STARTED
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
   })
@@ -50,10 +50,10 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.WAITING_FOR_REPLY))
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_REPLY))
 
     const expectedSession = createTestSessionState()
-    expectedSession.state = ALERT_STATE.WAITING_FOR_REPLY
+    expectedSession.state = CHATBOT_STATE.WAITING_FOR_REPLY
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
   })
@@ -62,10 +62,10 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.WAITING_FOR_CATEGORY))
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_CATEGORY))
 
     const expectedSession = createTestSessionState()
-    expectedSession.state = ALERT_STATE.WAITING_FOR_CATEGORY
+    expectedSession.state = CHATBOT_STATE.WAITING_FOR_CATEGORY
     expectedSession.respondedAt = this.fakeCurrentTime
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
@@ -75,10 +75,10 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.WAITING_FOR_DETAILS))
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_DETAILS))
 
     const expectedSession = createTestSessionState()
-    expectedSession.state = ALERT_STATE.WAITING_FOR_DETAILS
+    expectedSession.state = CHATBOT_STATE.WAITING_FOR_DETAILS
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
   })
@@ -87,10 +87,10 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.COMPLETED))
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.COMPLETED))
 
     const expectedSession = createTestSessionState()
-    expectedSession.state = ALERT_STATE.COMPLETED
+    expectedSession.state = CHATBOT_STATE.COMPLETED
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
   })
@@ -99,10 +99,10 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.WAITING_FOR_DETAILS, '0'))
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_DETAILS, '0'))
 
     const expectedSession = createTestSessionState()
-    expectedSession.state = ALERT_STATE.WAITING_FOR_DETAILS
+    expectedSession.state = CHATBOT_STATE.WAITING_FOR_DETAILS
     expectedSession.incidentType = 'Cat0'
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
@@ -112,10 +112,10 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, ALERT_STATE.COMPLETED, undefined, 'fakeDetails'))
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.COMPLETED, undefined, 'fakeDetails'))
 
     const expectedSession = createTestSessionState()
-    expectedSession.state = ALERT_STATE.COMPLETED
+    expectedSession.state = CHATBOT_STATE.COMPLETED
     expectedSession.notes = 'fakeDetails'
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)

--- a/server/test/unit/BraveAlerterConfiguratorTest/getReturnMessageTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/getReturnMessageTest.js
@@ -3,7 +3,7 @@ const { expect } = require('chai')
 const { before, describe, it } = require('mocha')
 
 // In-house dependencies
-const { ALERT_STATE } = require('brave-alert-lib')
+const { CHATBOT_STATE } = require('brave-alert-lib')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator.js')
 
 describe('BraveAlerterConfigurator.js unit tests: getReturnMessage', () => {
@@ -14,28 +14,31 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessage', () => {
   })
 
   it('should get message when STARTED => WAITING_FOR_REPLY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.STARTED, ALERT_STATE.WAITING_FOR_REPLY, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.STARTED, CHATBOT_STATE.WAITING_FOR_REPLY, ['Cat0', 'Cat1'])
     expect(returnMessage).to.equal(
       'Now that you have responded, please reply with the number that best describes the incident:\n0 - Cat0\n1 - Cat1\n',
     )
   })
 
   it('should get message when STARTED => WAITING_FOR_CATEGORY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.STARTED, ALERT_STATE.WAITING_FOR_CATEGORY, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.STARTED, CHATBOT_STATE.WAITING_FOR_CATEGORY, ['Cat0', 'Cat1'])
     expect(returnMessage).to.equal(
       'Now that you have responded, please reply with the number that best describes the incident:\n0 - Cat0\n1 - Cat1\n',
     )
   })
 
   it('should get message when WAITING_FOR_REPLY => WAITING_FOR_CATEGORY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.WAITING_FOR_REPLY, ALERT_STATE.WAITING_FOR_CATEGORY, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.WAITING_FOR_REPLY, CHATBOT_STATE.WAITING_FOR_CATEGORY, [
+      'Cat0',
+      'Cat1',
+    ])
     expect(returnMessage).to.equal(
       'Now that you have responded, please reply with the number that best describes the incident:\n0 - Cat0\n1 - Cat1\n',
     )
   })
 
   it('should get message when WAITING_FOR_CATEGORY => WAITING_FOR_CATEGORY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.WAITING_FOR_CATEGORY, ALERT_STATE.WAITING_FOR_CATEGORY, [
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.WAITING_FOR_CATEGORY, CHATBOT_STATE.WAITING_FOR_CATEGORY, [
       'Cat0',
       'Cat1',
     ])
@@ -43,22 +46,25 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessage', () => {
   })
 
   it('should get message when WAITING_FOR_CATEGORY => WAITING_FOR_DETAILS', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.WAITING_FOR_CATEGORY, ALERT_STATE.WAITING_FOR_DETAILS, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.WAITING_FOR_CATEGORY, CHATBOT_STATE.WAITING_FOR_DETAILS, [
+      'Cat0',
+      'Cat1',
+    ])
     expect(returnMessage).to.equal('Thank you. If you like, you can reply with any further details about the incident.')
   })
 
   it('should get message when WAITING_FOR_DETAILS => COMPLETED', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.WAITING_FOR_DETAILS, ALERT_STATE.COMPLETED, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.WAITING_FOR_DETAILS, CHATBOT_STATE.COMPLETED, ['Cat0', 'Cat1'])
     expect(returnMessage).to.equal("Thank you. This session is now complete. (You don't need to respond to this message.)")
   })
 
   it('should get message when COMPLETED => COMPLETED', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.COMPLETED, ALERT_STATE.COMPLETED, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.COMPLETED, CHATBOT_STATE.COMPLETED, ['Cat0', 'Cat1'])
     expect(returnMessage).to.equal("There is no active session for this button. (You don't need to respond to this message.)")
   })
 
   it('should get default message if given something funky', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage('something funky', ALERT_STATE.COMPLETED, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage('something funky', CHATBOT_STATE.COMPLETED, ['Cat0', 'Cat1'])
     expect(returnMessage).to.equal(
       'Thank you for responding. Unfortunately, we have encountered an error in our system and will deal with it shortly.',
     )

--- a/server/test/unit/SessionStateTest.js
+++ b/server/test/unit/SessionStateTest.js
@@ -4,7 +4,7 @@ const expect = chai.expect
 const beforeEach = require('mocha').beforeEach
 const describe = require('mocha').describe
 const it = require('mocha').it
-const ALERT_STATE = require('brave-alert-lib').ALERT_STATE
+const CHATBOT_STATE = require('brave-alert-lib').CHATBOT_STATE
 
 const SessionState = require('../../SessionState.js')
 
@@ -20,7 +20,7 @@ describe('SessionState class', () => {
   let state
 
   beforeEach(() => {
-    state = new SessionState(sessionId, installationId, buttonId, unit, phoneNumber, ALERT_STATE.STARTED, 1, createdAt, updatedAt, null, null)
+    state = new SessionState(sessionId, installationId, buttonId, unit, phoneNumber, CHATBOT_STATE.STARTED, 1, createdAt, updatedAt, null, null)
   })
 
   it('should start off with 1 button press', () => {


### PR DESCRIPTION
- To upgrade `brave-alert-lib`

## Test Plan
- :heavy_check_mark: Deploy to chatbot-dev.brave.coop
   - :heavy_check_mark: Trigger both a Not-Urgent and Urgent Alert using my test Button
   - :heavy_check_mark: Go through all chatbot states: Started, Waiting for Reply, Waiting for Incident Category, Waiting for Details, Completed