### PR TITLE
Add OneSignal Push notifications (CU-10xfkhr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,16 @@ the code was deployed.
 
 ## Unreleased
 
+### Added
+
+- `responder_push_id` to the DB to store the Responder Device's Push Notification ID (CU-10xfkhr).
+- `POST /alert/acknowledgeAlertSession` to acknowledge an alert session through the Alert App (CU-10xfkhr).
+- `POST /alert/setIncidentCategory` to set the incident category for an alert session through the Alert App (CU-10xfkhr).
+
 ### Changed
 
 - Updated `ALERT_STATE` to `CHATBOT_STATE`.
+- `POST /alert/designatedevice` also logs the given Responder Push ID (CU-10xfkhr).
 
 ## [4.1.0] - 2021-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ the code was deployed.
 
 - `responder_push_id` to the DB to store the Responder Device's Push Notification ID (CU-10xfkhr).
 - `POST /alert/acknowledgeAlertSession` to acknowledge an alert session through the Alert App (CU-10xfkhr).
+- `POST /alert/respondToAlertSession` to respond to an alert session through the Alert App (CU-10xfkhr).
 - `POST /alert/setIncidentCategory` to set the incident category for an alert session through the Alert App (CU-10xfkhr).
+- `GET /alert/activeAlerts` endpoint (CU-10xfkhr).
 
 ### Changed
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -76,3 +76,11 @@ SENTRY_RELEASE=examplerelease
 # Any new Button presses after a period of this much inactivity will start a new session
 SESSION_RESET_TIMEOUT=7200000
 SESSION_RESET_TIMEOUT_TEST=7200000
+
+# OneSignal App ID from OneSignal --> Settings --> Keys & IDs --> OneSignal App ID
+ONESIGNAL_APP_ID=guid-here
+ONESIGNAL_APP_ID_TEST=guid-here
+
+# OneSignal App ID from OneSignal --> Settings --> Keys & IDs --> REST API Key
+ONESIGNAL_API_KEY=jumbleOfCharactersHere
+ONESIGNAL_API_KEY_TEST=jumbleOfCharactersHere

--- a/server/Installation.js
+++ b/server/Installation.js
@@ -1,5 +1,5 @@
 class Installation {
-  constructor(id, name, responderPhoneNumber, fallbackPhoneNumbers, incidentCategories, isActive, createdAt, alertApiKey) {
+  constructor(id, name, responderPhoneNumber, fallbackPhoneNumbers, incidentCategories, isActive, createdAt, alertApiKey, responderPushId) {
     this.id = id
     this.name = name
     this.responderPhoneNumber = responderPhoneNumber
@@ -8,6 +8,7 @@ class Installation {
     this.isActive = isActive
     this.createdAt = createdAt
     this.alertApiKey = alertApiKey
+    this.responderPushId = responderPushId
   }
 }
 

--- a/server/db/016-addresponderpushidtoinstallations.sql
+++ b/server/db/016-addresponderpushidtoinstallations.sql
@@ -1,0 +1,21 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 16;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        ALTER TABLE installations 
+        ADD COLUMN responder_push_id text;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -524,47 +524,47 @@
       "dev": true
     },
     "@sentry/core": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.11.0.tgz",
-      "integrity": "sha512-09TB+f3pqEq8LFahFWHO6I/4DxHo+NcS52OkbWMDqEi6oNZRD7PhPn3i14LfjsYVv3u3AESU8oxSEGbFrr2UjQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
+      "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
       "requires": {
-        "@sentry/hub": "6.11.0",
-        "@sentry/minimal": "6.11.0",
-        "@sentry/types": "6.11.0",
-        "@sentry/utils": "6.11.0",
+        "@sentry/hub": "6.12.0",
+        "@sentry/minimal": "6.12.0",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.11.0.tgz",
-      "integrity": "sha512-pT9hf+ZJfVFpoZopoC+yJmFNclr4NPqPcl2cgguqCHb69DklD1NxgBNWK8D6X05qjnNFDF991U6t1mxP9HrGuw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
+      "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
       "requires": {
-        "@sentry/types": "6.11.0",
-        "@sentry/utils": "6.11.0",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.11.0.tgz",
-      "integrity": "sha512-XkZ7qrdlGp4IM/gjGxf1Q575yIbl5RvPbg+WFeekpo16Ufvzx37Mr8c2xsZaWosISVyE6eyFpooORjUlzy8EDw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
+      "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
       "requires": {
-        "@sentry/hub": "6.11.0",
-        "@sentry/types": "6.11.0",
+        "@sentry/hub": "6.12.0",
+        "@sentry/types": "6.12.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.11.0.tgz",
-      "integrity": "sha512-vbk+V/n7ZIFD8rHPYy03t/gIG5V7LGdjU4qJxVDgNZzticfWPnd2sLgle/r+l60XF6SKW/epG4rnxnBcgPdWaw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.12.0.tgz",
+      "integrity": "sha512-hfAU3cX5sNWgqyDQBCOIQOZj21l0w1z2dG4MjmrMMHKrQ18pfMaaOtEwRXMCdjTUlwsK+L3TOoUB23lbezmu1A==",
       "requires": {
-        "@sentry/core": "6.11.0",
-        "@sentry/hub": "6.11.0",
-        "@sentry/tracing": "6.11.0",
-        "@sentry/types": "6.11.0",
-        "@sentry/utils": "6.11.0",
+        "@sentry/core": "6.12.0",
+        "@sentry/hub": "6.12.0",
+        "@sentry/tracing": "6.12.0",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -572,28 +572,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.11.0.tgz",
-      "integrity": "sha512-9VA1/SY++WeoMQI4K6n/sYgIdRtCu9NLWqmGqu/5kbOtESYFgAt1DqSyqGCr00ZjQiC2s7tkDkTNZb38K6KytQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
+      "integrity": "sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==",
       "requires": {
-        "@sentry/hub": "6.11.0",
-        "@sentry/minimal": "6.11.0",
-        "@sentry/types": "6.11.0",
-        "@sentry/utils": "6.11.0",
+        "@sentry/hub": "6.12.0",
+        "@sentry/minimal": "6.12.0",
+        "@sentry/types": "6.12.0",
+        "@sentry/utils": "6.12.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.11.0.tgz",
-      "integrity": "sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg=="
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
+      "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA=="
     },
     "@sentry/utils": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.11.0.tgz",
-      "integrity": "sha512-IOvyFHcnbRQxa++jO+ZUzRvFHEJ1cZjrBIQaNVc0IYF0twUOB5PTP6joTcix38ldaLeapaPZ9LGfudbvYvxkdg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
+      "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
       "requires": {
-        "@sentry/types": "6.11.0",
+        "@sentry/types": "6.12.0",
         "tslib": "^1.9.3"
       }
     },
@@ -1052,8 +1052,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#057c718f127f54c9cc3a8b423ba85cfcbca5586d",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#td-add-onesignal",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#7b352451ae274c9dc3634d8ac479d1dbf8136a8c",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#td-add-onesignal-part-2",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1052,11 +1052,12 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#5d22132bb4510841553fa50cf0863f7bc98a3c5a",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v4.0.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#057c718f127f54c9cc3a8b423ba85cfcbca5586d",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#td-add-onesignal",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
+        "axios": "^0.21.1",
         "body-parser": "^1.19.0",
         "chalk": "^4.1.0",
         "dotenv": "^7.0.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -524,47 +524,47 @@
       "dev": true
     },
     "@sentry/core": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.12.0.tgz",
-      "integrity": "sha512-mU/zdjlzFHzdXDZCPZm8OeCw7c9xsbL49Mq0TrY0KJjLt4CJBkiq5SDTGfRsenBLgTedYhe5Z/J8Z+xVVq+MfQ==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.2.tgz",
+      "integrity": "sha512-snXNNFLwlS7yYxKTX4DBXebvJK+6ikBWN6noQ1CHowvM3ReFBlrdrs0Z0SsSFEzXm2S4q7f6HHbm66GSQZ/8FQ==",
       "requires": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "6.13.2",
+        "@sentry/minimal": "6.13.2",
+        "@sentry/types": "6.13.2",
+        "@sentry/utils": "6.13.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.12.0.tgz",
-      "integrity": "sha512-yR/UQVU+ukr42bSYpeqvb989SowIXlKBanU0cqLFDmv5LPCnaQB8PGeXwJAwWhQgx44PARhmB82S6Xor8gYNxg==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.2.tgz",
+      "integrity": "sha512-sppSuJdNMiMC/vFm/dQowCBh11uTrmvks00fc190YWgxHshodJwXMdpc+pN61VSOmy2QA4MbQ5aMAgHzPzel3A==",
       "requires": {
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/types": "6.13.2",
+        "@sentry/utils": "6.13.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.12.0.tgz",
-      "integrity": "sha512-r3C54Q1KN+xIqUvcgX9DlcoWE7ezWvFk2pSu1Ojx9De81hVqR9u5T3sdSAP2Xma+um0zr6coOtDJG4WtYlOtsw==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.2.tgz",
+      "integrity": "sha512-6iJfEvHzzpGBHDfLxSHcGObh73XU1OSQKWjuhDOe7UQDyI4BQmTfcXAC+Fr8sm8C/tIsmpVi/XJhs8cubFdSMw==",
       "requires": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/types": "6.12.0",
+        "@sentry/hub": "6.13.2",
+        "@sentry/types": "6.13.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.12.0.tgz",
-      "integrity": "sha512-hfAU3cX5sNWgqyDQBCOIQOZj21l0w1z2dG4MjmrMMHKrQ18pfMaaOtEwRXMCdjTUlwsK+L3TOoUB23lbezmu1A==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.13.2.tgz",
+      "integrity": "sha512-0Vw22amG143MTiNaSny66YGU3+uW7HxyGI9TLGE7aJY1nNmC0DE+OgqQYGBRCrrPu+VFXRDxrOg9b15A1gKqjA==",
       "requires": {
-        "@sentry/core": "6.12.0",
-        "@sentry/hub": "6.12.0",
-        "@sentry/tracing": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/core": "6.13.2",
+        "@sentry/hub": "6.13.2",
+        "@sentry/tracing": "6.13.2",
+        "@sentry/types": "6.13.2",
+        "@sentry/utils": "6.13.2",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -572,28 +572,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.12.0.tgz",
-      "integrity": "sha512-u10QHNknPBzbWSUUNMkvuH53sQd5NaBo6YdNPj4p5b7sE7445Sh0PwBpRbY3ZiUUiwyxV59fx9UQ4yVnPGxZQA==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.13.2.tgz",
+      "integrity": "sha512-bHJz+C/nd6biWTNcYAu91JeRilsvVgaye4POkdzWSmD0XoLWHVMrpCQobGpXe7onkp2noU3YQjhqgtBqPHtnpw==",
       "requires": {
-        "@sentry/hub": "6.12.0",
-        "@sentry/minimal": "6.12.0",
-        "@sentry/types": "6.12.0",
-        "@sentry/utils": "6.12.0",
+        "@sentry/hub": "6.13.2",
+        "@sentry/minimal": "6.13.2",
+        "@sentry/types": "6.13.2",
+        "@sentry/utils": "6.13.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.12.0.tgz",
-      "integrity": "sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA=="
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.2.tgz",
+      "integrity": "sha512-6WjGj/VjjN8LZDtqJH5ikeB1o39rO1gYS6anBxiS3d0sXNBb3Ux0pNNDFoBxQpOhmdDHXYS57MEptX9EV82gmg=="
     },
     "@sentry/utils": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.12.0.tgz",
-      "integrity": "sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.2.tgz",
+      "integrity": "sha512-foF4PbxqPMWNbuqdXkdoOmKm3quu3PP7Q7j/0pXkri4DtCuvF/lKY92mbY0V9rHS/phCoj+3/Se5JvM2ymh2/w==",
       "requires": {
-        "@sentry/types": "6.12.0",
+        "@sentry/types": "6.13.2",
         "tslib": "^1.9.3"
       }
     },
@@ -1052,18 +1052,28 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#7b352451ae274c9dc3634d8ac479d1dbf8136a8c",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#td-add-onesignal-part-2",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#90ed987a3f65d155a0e6464914f93db4444cd5c4",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v5.0.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
-        "axios": "^0.21.1",
+        "axios": "^0.21.2",
         "body-parser": "^1.19.0",
         "chalk": "^4.1.0",
         "dotenv": "^7.0.0",
         "express": "^4.17.1",
         "express-validator": "^6.10.0",
         "twilio": "^3.54.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        }
       }
     },
     "browser-stdout": {

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.18.3",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v4.0.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#td-add-onesignal",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "express-session": "^1.15.6",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.18.3",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#td-add-onesignal",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#td-add-onesignal-part-2",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "express-session": "^1.15.6",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.18.3",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#td-add-onesignal-part-2",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v5.0.0",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "express-session": "^1.15.6",

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -14,3 +14,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USE
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/013-addapikeytoinstallations.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/014-addrespondedattosessions.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/015-addnotifications.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/016-addresponderpushidtoinstallations.sql

--- a/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
@@ -17,14 +17,11 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
     this.installationResponderPhoneNumber = '+17775558888'
     this.installationIncidentCategories = ['Cat1', 'Cat2', 'Cat3']
 
-    await db.clearSessions()
-    await db.clearNotifications()
-    await db.clearInstallations()
-    await db.createInstallation('', this.installationResponderPhoneNumber, '{}', this.installationIncidentCategories, null)
+    await db.clearTables()
+
+    await db.createInstallation('', this.installationResponderPhoneNumber, '{}', this.installationIncidentCategories, null, null)
     const installations = await db.getInstallations()
-    await db.createSession(installations[0].id, '', '701', this.sessionToPhoneNumber, 1)
-    const sessions = await db.getAllSessions()
-    const session = sessions[0]
+    const session = await db.createSession(installations[0].id, '', '701', this.sessionToPhoneNumber, 1)
     this.sessionId = session.id
     session.state = this.sessionState
     session.incidentType = this.sessionIncidentType
@@ -33,9 +30,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
   })
 
   afterEach(async () => {
-    await db.clearSessions()
-    await db.clearNotifications()
-    await db.clearInstallations()
+    await db.clearTables()
   })
 
   it('should return an AlertSession with the values from the DB', async () => {

--- a/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionBySessionidAndAlertApiKeyTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionBySessionidAndAlertApiKeyTest.js
@@ -7,22 +7,22 @@ const { CHATBOT_STATE, AlertSession } = require('brave-alert-lib')
 const db = require('../../../db/db.js')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator.js')
 
-describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () => {
+describe('BraveAlerterConfigurator.js integration tests: getAlertSessionBySessionidAndAlertApiKey', () => {
   beforeEach(async () => {
     this.sessionState = CHATBOT_STATE.WAITING_FOR_DETAILS
     this.sessionIncidentType = '2'
     this.sessionNotes = 'sessionNotes'
+    this.sessionToPhoneNumber = '+13335557777'
     this.message = 'message'
     this.installationResponderPhoneNumber = '+17775558888'
     this.installationIncidentCategories = ['Cat1', 'Cat2', 'Cat3']
+    this.alertApiKey = 'myApiKey'
 
     await db.clearTables()
 
-    await db.createInstallation('', this.installationResponderPhoneNumber, '{}', this.installationIncidentCategories, null, null)
+    await db.createInstallation('', this.installationResponderPhoneNumber, '{}', this.installationIncidentCategories, this.alertApiKey, null)
     const installations = await db.getInstallations()
-    await db.createSession(installations[0].id, '', '701', '', 1, null)
-    const sessions = await db.getAllSessions()
-    const session = sessions[0]
+    const session = await db.createSession(installations[0].id, '', '701', this.sessionToPhoneNumber, 1)
     this.sessionId = session.id
     session.state = this.sessionState
     session.incidentType = this.sessionIncidentType
@@ -37,7 +37,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
   it('should return an AlertSession with the values from the DB', async () => {
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-    const alertSession = await braveAlerter.getAlertSession(this.sessionId)
+    const alertSession = await braveAlerter.getAlertSessionBySessionIdAndAlertApiKey(this.sessionId, this.alertApiKey)
 
     expect(alertSession).to.eql(
       new AlertSession(

--- a/server/test/integration/BraveAlerterConfiguratorTest/getNewNotificationsCountByAlertApiKeyTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getNewNotificationsCountByAlertApiKeyTest.js
@@ -8,9 +8,7 @@ const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator.js')
 
 describe('BraveAlerterConfigurator.js integration tests: getNewNotificationsCountByAlertApiKey', () => {
   beforeEach(async () => {
-    await db.clearSessions()
-    await db.clearNotifications()
-    await db.clearInstallations()
+    await db.clearTables()
 
     this.alertApiKey = '00000000-000000000000001'
     await db.createInstallation('', '', '{}', '{}', this.alertApiKey)
@@ -28,9 +26,7 @@ describe('BraveAlerterConfigurator.js integration tests: getNewNotificationsCoun
   })
 
   afterEach(async () => {
-    await db.clearSessions()
-    await db.clearNotifications()
-    await db.clearInstallations()
+    await db.clearTables()
   })
 
   it('should properly count notifications that match the api key ', async () => {

--- a/server/test/integration/dbTest/getActiveAlertsByAlertApiKeyTest.js
+++ b/server/test/integration/dbTest/getActiveAlertsByAlertApiKeyTest.js
@@ -1,0 +1,264 @@
+// Third-party dependencies
+const { expect } = require('chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const { CHATBOT_STATE, ALERT_TYPE } = require('brave-alert-lib')
+
+// In-house dependencies
+const db = require('../../../db/db.js')
+const SessionState = require('../../../SessionState.js')
+
+describe('db.js integration tests: getActiveAlertsByAlertApiKey', () => {
+  describe('if there are no installations with the given Alert API Key', () => {
+    beforeEach(async () => {
+      await db.clearTables()
+
+      // Insert a single installation with a single button that has a single session that doesn't match the Alert API Key that we ask for
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1","cat2"}', 'alertApiKey', 'pushId')
+      const installationId = (await db.getInstallations())[0].id
+      const buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
+      await db.createButton(buttonId, installationId, 'unit', 'phoneNumber', 'serialNumber')
+      await db.createSession(installationId, buttonId, 'unit', 'phoneNumber', 5, 95, new Date())
+    })
+
+    afterEach(async () => {
+      await db.clearTables()
+    })
+
+    it('should return an empty array', async () => {
+      const rows = await db.getActiveAlertsByAlertApiKey('not alertApiKey', 50000)
+
+      expect(rows).to.eql([])
+    })
+  })
+
+  describe('if there are no sessions for the installation with the given Alert API Key', () => {
+    beforeEach(async () => {
+      await db.clearTables()
+
+      // Insert a single installation with a single button that has a single session that doesn't match the Alert API Key that we ask for
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', 'not our API key', 'pushId')
+      const installationId = (await db.getInstallations())[0].id
+      const buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
+      await db.createButton(buttonId, installationId, 'unit', 'phoneNumber', 'serialNumber')
+      await db.createSession(installationId, buttonId, 'unit', 'phoneNumber', 5, 95, new Date())
+
+      // Insert a single installation with no sessions that matches the Alert API Key that we ask for
+      this.alertApiKey = 'alertApiKey'
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey)
+    })
+
+    afterEach(async () => {
+      await db.clearTables()
+    })
+
+    it('should return an empty array', async () => {
+      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 50000)
+
+      expect(rows).to.eql([])
+    })
+  })
+
+  describe('if there is one matching session', () => {
+    beforeEach(async () => {
+      await db.clearTables()
+
+      // Insert a single installation with a single button
+      this.alertApiKey = 'alertApiKey'
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1","cat2"}', this.alertApiKey, 'pushId')
+      this.installationId = (await db.getInstallations())[0].id
+      this.buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
+      this.unit = 'unit1'
+      await db.createButton(this.buttonId, this.installationId, this.unit, 'phoneNumber1', 'serialNumber1')
+
+      // Insert a single session for that API key
+      this.incidentType = ALERT_TYPE.BUTTONS_URGENT
+      this.numPresses = 6
+      this.respondedAt = new Date('2021-01-20T06:20:19.000Z')
+      this.session = await db.createSession(this.installationId, this.buttonId, this.unit, 'phoneNumber', this.numPresses, 95, this.respondedAt)
+      await db.saveSession(
+        new SessionState(
+          this.session.id,
+          this.session.installationId,
+          this.session.buttonId,
+          this.session.unit,
+          this.session.phoneNumber,
+          CHATBOT_STATE.WAITING_FOR_CATEGORY,
+          this.numPresses,
+          this.session.createdAt,
+          new Date(),
+          null,
+          '',
+          '',
+          this.session.buttonBatteryLevel,
+          this.respondedAt,
+        ),
+      )
+    })
+
+    afterEach(async () => {
+      await db.clearTables()
+    })
+
+    it('should return an array with one object with the correct values in it', async () => {
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 120000)
+
+      expect(rows).to.eql([
+        {
+          id: this.session.id,
+          state: CHATBOT_STATE.WAITING_FOR_CATEGORY,
+          unit: this.unit,
+          num_presses: this.numPresses,
+          incident_categories: ['cat1', 'cat2'],
+          created_at: this.session.createdAt,
+        },
+      ])
+    })
+  })
+
+  describe('if the session was more recent than maxTimeAgoInMillis', () => {
+    beforeEach(async () => {
+      await db.clearTables()
+
+      // Insert a single installation with a one button and one session
+      this.alertApiKey = 'alertApiKey'
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey, 'pushId')
+      const installationId = (await db.getInstallations())[0].id
+      const buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
+      const unit = 'unit1'
+      await db.createButton(buttonId, installationId, unit, 'phoneNumber1', 'serialNumber1')
+      this.session = await db.createSession(installationId, buttonId, unit, 'phoneNumber', '1', 95, new Date('2021-01-20T06:20:19.000Z'))
+    })
+
+    afterEach(async () => {
+      await db.clearTables()
+    })
+
+    it('and it is COMPLETED, should not return it', async () => {
+      // Update the session to COMPLETED
+      const updatedSession = { ...this.session }
+      updatedSession.state = CHATBOT_STATE.COMPLETED
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+
+    it('and it is WAITING_FOR_CATEGORY, should return the session', async () => {
+      // Update the session to WAITING_FOR_CATEGORY
+      const updatedSession = { ...this.session }
+      updatedSession.state = CHATBOT_STATE.WAITING_FOR_CATEGORY
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([this.session.id])
+    })
+
+    it('and it is WAITING_FOR_REPLY, should return the session', async () => {
+      // Update the session to WAITING_FOR_REPLY
+      const updatedSession = { ...this.session }
+      updatedSession.state = CHATBOT_STATE.WAITING_FOR_REPLY
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([this.session.id])
+    })
+
+    it('and it is STARTED, should return the session', async () => {
+      // Update the session to STARTED
+      const updatedSession = { ...this.session }
+      updatedSession.state = CHATBOT_STATE.STARTED
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([this.session.id])
+    })
+  })
+
+  describe('if the session was longer ago than maxTimeAgoInMillis', () => {
+    beforeEach(async () => {
+      await db.clearTables()
+
+      // Insert a single installation with a one button and one session
+      this.alertApiKey = 'alertApiKey'
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey, 'pushId')
+      const installationId = (await db.getInstallations())[0].id
+      const buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
+      const unit = 'unit1'
+      await db.createButton(buttonId, installationId, unit, 'phoneNumber1', 'serialNumber1')
+      this.session = await db.createSession(installationId, buttonId, unit, 'phoneNumber', '1', 95, new Date('2021-01-20T06:20:19.000Z'))
+    })
+
+    afterEach(async () => {
+      await db.clearTables()
+    })
+
+    it('and it is COMPLETED, should not return it', async () => {
+      // Update the session to COMPLETED
+      const updatedSession = { ...this.session }
+      updatedSession.state = CHATBOT_STATE.COMPLETED
+      await db.saveSession(updatedSession)
+
+      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 1)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+
+    it('and it is WAITING_FOR_CATEGORY, should not return it', async () => {
+      // Update the session to WAITING_FOR_CATEGORY
+      const updatedSession = { ...this.session }
+      updatedSession.state = CHATBOT_STATE.WAITING_FOR_CATEGORY
+      await db.saveSession(updatedSession)
+
+      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 1)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+
+    it('and it is WAITING_FOR_REPLY, should not return it', async () => {
+      // Update the session to WAITING_FOR_REPLY
+      const updatedSession = { ...this.session }
+      updatedSession.state = CHATBOT_STATE.WAITING_FOR_REPLY
+      await db.saveSession(updatedSession)
+
+      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 1)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+
+    it('and it is STARTED, should not return it', async () => {
+      // Update the session to STARTED
+      const updatedSession = { ...this.session }
+      updatedSession.state = CHATBOT_STATE.STARTED
+      await db.saveSession(updatedSession)
+
+      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 1)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+  })
+})

--- a/server/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
+++ b/server/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
@@ -10,13 +10,10 @@ const SessionState = require('../../../SessionState.js')
 describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
   describe('if there are no installations with the given Alert API Key', () => {
     beforeEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
 
       // Insert a single installation with a single button that has a single session that doesn't match the Alert API Key that we ask for
-      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', 'alertApiKey')
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', 'alertApiKey', 'pushId')
       const installationId = (await db.getInstallations())[0].id
       const buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
       await db.createButton(buttonId, installationId, 'unit', 'phoneNumber', 'serialNumber')
@@ -24,10 +21,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
     })
 
     afterEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
     })
 
     it('should return an empty array', async () => {
@@ -39,13 +33,10 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
 
   describe('if there are no sessions for the installation with the given Alert API Key', () => {
     beforeEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
 
       // Insert a single installation with a single button that has a single session that doesn't match the Alert API Key that we ask for
-      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', 'not our API key')
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', 'not our API key', 'pushId')
       const installationId = (await db.getInstallations())[0].id
       const buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
       await db.createButton(buttonId, installationId, 'unit', 'phoneNumber', 'serialNumber')
@@ -57,10 +48,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
     })
 
     afterEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
     })
 
     it('should return an empty array', async () => {
@@ -72,14 +60,11 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
 
   describe('if there is one matching session', () => {
     beforeEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
 
       // Insert a single installation with a single button
       this.alertApiKey = 'alertApiKey'
-      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey)
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey, 'pushId')
       this.installationId = (await db.getInstallations())[0].id
       this.buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
       this.unit = 'unit1'
@@ -111,10 +96,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
     })
 
     afterEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
     })
 
     it('should return an array with one object with the correct values in it', async () => {
@@ -135,14 +117,11 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
 
   describe('if there are more matching sessions than maxHistoricAlerts', () => {
     beforeEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
 
       // Insert a single installation with a two buttons and more than maxHistoricAlerts sessions
       this.alertApiKey = 'alertApiKey'
-      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey)
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey, 'pushId')
       const installationId = (await db.getInstallations())[0].id
       const buttonId1 = '51b8be5678bf5ade9bf6a5958b2a4a45'
       await db.createButton(buttonId1, installationId, 'unit1', 'phoneNumber1', 'serialNumber1')
@@ -156,10 +135,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
     })
 
     afterEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
     })
 
     it('should return only the most recent maxHistoricAlerts of them', async () => {
@@ -173,14 +149,11 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
 
   describe('if there are fewer matching sessions than maxHistoricAlerts', () => {
     beforeEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
 
       // Insert a single installation with a two buttons and maxHistoricAlerts sessions
       this.alertApiKey = 'alertApiKey'
-      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey)
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey, 'pushId')
       const installationId = (await db.getInstallations())[0].id
       const buttonId1 = '51b8be5678bf5ade9bf6a5958b2a4a45'
       await db.createButton(buttonId1, installationId, 'unit1', 'phoneNumber1', 'serialNumber1')
@@ -195,10 +168,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
     })
 
     afterEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
     })
 
     it('should return only the matches', async () => {
@@ -213,14 +183,11 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
 
   describe('if is a session more recent than maxTimeAgoInMillis', () => {
     beforeEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
 
       // Insert a single installation with a one button and one session
       this.alertApiKey = 'alertApiKey'
-      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey)
+      await db.createInstallation('name', 'responderNumber', '{"fallbackNumber"}', '{"cat1"}', this.alertApiKey, 'pushId')
       const installationId = (await db.getInstallations())[0].id
       const buttonId = '51b8be5678bf5ade9bf6a5958b2a4a45'
       const unit = 'unit1'
@@ -229,10 +196,7 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
     })
 
     afterEach(async () => {
-      await db.clearSessions()
-      await db.clearButtons()
-      await db.clearNotifications()
-      await db.clearInstallations()
+      await db.clearTables()
     })
 
     it('and it is COMPLETED, should return the Completed session', async () => {

--- a/server/test/unit/BraveAlerterConfiguratorTest/getActiveAlertsByAlertApiKeyTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/getActiveAlertsByAlertApiKeyTest.js
@@ -1,0 +1,116 @@
+// Third-party dependencies
+const { expect, use } = require('chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+
+const { helpers, ActiveAlert, ALERT_TYPE, CHATBOT_STATE } = require('brave-alert-lib')
+const db = require('../../../db/db.js')
+const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator.js')
+
+// Configure Chai
+use(sinonChai)
+
+const sandbox = sinon.createSandbox()
+
+describe('BraveAlerterConfigurator.js unit tests: getActiveAlertsByAlertApiKey and createActiveAlertFromRow', () => {
+  beforeEach(() => {
+    this.maxTimeAgoInMillis = 60000
+    sandbox.stub(helpers, 'getEnvVar').returns(this.maxTimeAgoInMillis)
+
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    this.braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('if there is a single result from db.getActiveAlertsByAlertApiKey with num_presses > 1, returns an array containing a single ActiveAlert object with the returned data and ALERT_TYPE.BUTTONS_URGENT', async () => {
+    const results = {
+      id: 'id',
+      state: CHATBOT_STATE.STARTED,
+      unit: 'unit',
+      num_presses: 2,
+      incident_categories: ['Cat1', 'Cat2'],
+      created_at: new Date(),
+    }
+    sandbox.stub(db, 'getActiveAlertsByAlertApiKey').returns([results])
+
+    const activeAlerts = await this.braveAlerter.getActiveAlertsByAlertApiKey('alertApiKey')
+
+    expect(activeAlerts).to.eql([
+      new ActiveAlert(results.id, results.state, results.unit, ALERT_TYPE.BUTTONS_URGENT, results.incident_categories, results.created_at),
+    ])
+  })
+
+  it('if there is a single result from db.getActiveAlertsByAlertApiKey with num_presses = 1, returns an array containing a single ActiveAlert object with the returned data and ALERT_TYPE.BUTTONS_NOT_URGENT', async () => {
+    const results = {
+      id: 'id',
+      state: CHATBOT_STATE.STARTED,
+      unit: 'unit',
+      num_presses: 1,
+      incident_categories: ['Cat1', 'Cat2'],
+      created_at: new Date(),
+    }
+    sandbox.stub(db, 'getActiveAlertsByAlertApiKey').returns([results])
+
+    const activeAlerts = await this.braveAlerter.getActiveAlertsByAlertApiKey('alertApiKey')
+
+    expect(activeAlerts).to.eql([
+      new ActiveAlert(results.id, results.state, results.unit, ALERT_TYPE.BUTTONS_NOT_URGENT, results.incident_categories, results.created_at),
+    ])
+  })
+
+  it('if there is a multiple results from db.getActiveAlertsByAlertApiKey, returns an array containing the ActiveAlert objects with the returned data', async () => {
+    const results1 = {
+      id: 'id1',
+      state: CHATBOT_STATE.STARTED,
+      unit: 'unit1',
+      num_presses: 1,
+      incident_categories: ['Cat1', 'Cat2'],
+      created_at: new Date(),
+    }
+    const results2 = {
+      id: 'id2',
+      state: CHATBOT_STATE.STARTED,
+      unit: 'unit2',
+      num_presses: 2,
+      incident_categories: ['Cat1', 'Cat2'],
+      created_at: new Date(),
+    }
+    sandbox.stub(db, 'getActiveAlertsByAlertApiKey').returns([results1, results2])
+
+    const activeAlerts = await this.braveAlerter.getActiveAlertsByAlertApiKey('alertApiKey')
+
+    expect(activeAlerts).to.eql([
+      new ActiveAlert(results1.id, results1.state, results1.unit, ALERT_TYPE.BUTTONS_NOT_URGENT, results1.incident_categories, results1.created_at),
+      new ActiveAlert(results2.id, results2.state, results2.unit, ALERT_TYPE.BUTTONS_URGENT, results2.incident_categories, results2.created_at),
+    ])
+  })
+
+  it('if there no results from db.getActiveAlertsByAlertApiKey, returns an empty array', async () => {
+    sandbox.stub(db, 'getActiveAlertsByAlertApiKey').returns([])
+
+    const activeAlerts = await this.braveAlerter.getActiveAlertsByAlertApiKey('alertApiKey')
+
+    expect(activeAlerts).to.eql([])
+  })
+
+  it('if db.getActiveAlertsByAlertApiKey returns a non-array, returns null', async () => {
+    sandbox.stub(db, 'getActiveAlertsByAlertApiKey').returns()
+
+    const activeAlerts = await this.braveAlerter.getActiveAlertsByAlertApiKey('alertApiKey')
+
+    expect(activeAlerts).to.be.null
+  })
+
+  it('db.getActiveAlertsByAlertApiKey is called with the given alertApiKey and the SESSION_RESET_TIMEOUT from .env', async () => {
+    sandbox.stub(db, 'getActiveAlertsByAlertApiKey')
+
+    const alertApiKey = 'alertApiKey'
+    await this.braveAlerter.getActiveAlertsByAlertApiKey(alertApiKey)
+
+    expect(db.getActiveAlertsByAlertApiKey).to.be.calledWith(alertApiKey, this.maxTimeAgoInMillis)
+  })
+})

--- a/server/test/unit/BraveAlerterConfiguratorTest/getHistoricAlertsByAlertApiKeyTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/getHistoricAlertsByAlertApiKeyTest.js
@@ -11,18 +11,19 @@ const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator.js')
 // Configure Chai
 use(sinonChai)
 
+const sandbox = sinon.createSandbox()
+
 describe('BraveAlerterConfigurator.js unit tests: getHistoricAlertsByAlertApiKey and createHistoricAlertFromRow', () => {
   beforeEach(() => {
     this.maxTimeAgoInMillis = 60000
-    sinon.stub(helpers, 'getEnvVar').returns(this.maxTimeAgoInMillis)
+    sandbox.stub(helpers, 'getEnvVar').returns(this.maxTimeAgoInMillis)
 
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     this.braveAlerter = braveAlerterConfigurator.createBraveAlerter()
   })
 
   afterEach(() => {
-    helpers.getEnvVar.restore()
-    db.getHistoricAlertsByAlertApiKey.restore()
+    sandbox.restore()
   })
 
   it('if there is a single result from db.getHistoricAlertsByAlertApiKey with num_presses > 1, returns an array containing a single HistoricAlert object with the returned data and ALERT_TYPE.BUTTONS_URGENT', async () => {
@@ -34,7 +35,7 @@ describe('BraveAlerterConfigurator.js unit tests: getHistoricAlertsByAlertApiKey
       created_at: new Date('2020-01-20T10:10:10.000Z'),
       responded_at: new Date('2020-01-20T10:12:40.000Z'),
     }
-    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns([results])
+    sandbox.stub(db, 'getHistoricAlertsByAlertApiKey').returns([results])
 
     const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
 
@@ -60,7 +61,7 @@ describe('BraveAlerterConfigurator.js unit tests: getHistoricAlertsByAlertApiKey
       created_at: new Date('2020-01-20T10:10:10.000Z'),
       responded_at: new Date('2020-01-20T10:12:40.000Z'),
     }
-    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns([results])
+    sandbox.stub(db, 'getHistoricAlertsByAlertApiKey').returns([results])
 
     const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
 
@@ -94,7 +95,7 @@ describe('BraveAlerterConfigurator.js unit tests: getHistoricAlertsByAlertApiKey
       created_at: new Date('2019-02-20T09:10:10.000Z'),
       responded_at: new Date('2019-02-20T09:12:40.000Z'),
     }
-    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns([results1, results2])
+    sandbox.stub(db, 'getHistoricAlertsByAlertApiKey').returns([results1, results2])
 
     const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
 
@@ -121,7 +122,7 @@ describe('BraveAlerterConfigurator.js unit tests: getHistoricAlertsByAlertApiKey
   })
 
   it('if there no results from db.getHistoricAlertsByAlertApiKey, returns an empty array', async () => {
-    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns([])
+    sandbox.stub(db, 'getHistoricAlertsByAlertApiKey').returns([])
 
     const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
 
@@ -129,7 +130,7 @@ describe('BraveAlerterConfigurator.js unit tests: getHistoricAlertsByAlertApiKey
   })
 
   it('if db.getHistoricAlertsByAlertApiKey returns a non-array, returns null', async () => {
-    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns()
+    sandbox.stub(db, 'getHistoricAlertsByAlertApiKey').returns()
 
     const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
 
@@ -137,7 +138,7 @@ describe('BraveAlerterConfigurator.js unit tests: getHistoricAlertsByAlertApiKey
   })
 
   it('db.getHistoricAlertsByAlertApiKey is called with the given alertApiKey, the given maxHistoricAlerts, and the SESSION_RESET_TIMEOUT from .env', async () => {
-    sinon.stub(db, 'getHistoricAlertsByAlertApiKey').returns()
+    sandbox.stub(db, 'getHistoricAlertsByAlertApiKey')
 
     const alertApiKey = 'alertApiKey'
     const maxHistoricAlerts = 'maxHistoricAlerts'

--- a/server/test/unit/BraveAlerterConfiguratorTest/getLocationByAlertApiKeyTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/getLocationByAlertApiKeyTest.js
@@ -19,7 +19,7 @@ describe('BraveAlerterConfigurator.js unit tests: getLocationByAlertApiKey', () 
   })
 
   afterEach(() => {
-    db.getInstallationsWithApiKey.restore()
+    db.getInstallationsWithAlertApiKey.restore()
   })
 
   it('if there is single installation with the given API key, returns a location with its display name and the Buttons system', async () => {
@@ -29,7 +29,7 @@ describe('BraveAlerterConfigurator.js unit tests: getLocationByAlertApiKey', () 
     const installationToReturn = new Installation()
     installationToReturn.alertApiKey = alertApiKey
     installationToReturn.name = displayName
-    sinon.stub(db, 'getInstallationsWithApiKey').returns([installationToReturn])
+    sinon.stub(db, 'getInstallationsWithAlertApiKey').returns([installationToReturn])
 
     const expectedLocation = new Location(displayName, SYSTEM.BUTTONS)
 
@@ -49,7 +49,7 @@ describe('BraveAlerterConfigurator.js unit tests: getLocationByAlertApiKey', () 
     const installation2 = new Installation()
     installation2.alertApiKey = alertApiKey
     installation2.name = 'aDifferentDisplayName'
-    sinon.stub(db, 'getInstallationsWithApiKey').returns([installation1, installation2])
+    sinon.stub(db, 'getInstallationsWithAlertApiKey').returns([installation1, installation2])
 
     const expectedLocation = new Location(displayName, SYSTEM.BUTTONS)
 
@@ -59,7 +59,7 @@ describe('BraveAlerterConfigurator.js unit tests: getLocationByAlertApiKey', () 
   })
 
   it('if there no installations with the given API key, returns null', async () => {
-    sinon.stub(db, 'getInstallationsWithApiKey').returns([])
+    sinon.stub(db, 'getInstallationsWithAlertApiKey').returns([])
 
     const actualLocation = await this.braveAlerter.getLocationByAlertApiKey('alertApiKey')
 
@@ -67,7 +67,7 @@ describe('BraveAlerterConfigurator.js unit tests: getLocationByAlertApiKey', () 
   })
 
   it('if db.getLocationByAlertApiKey returns a non-array, returns null', async () => {
-    sinon.stub(db, 'getInstallationsWithApiKey').returns()
+    sinon.stub(db, 'getInstallationsWithAlertApiKey').returns()
 
     const actualLocation = await this.braveAlerter.getLocationByAlertApiKey('alertApiKey')
 


### PR DESCRIPTION
- Updated brave-alert-lib to add the new endpoints for acknowledging an alert and setting an incident category and to change the behaviour of the designatedevice endpoint to also log the OneSignal Push ID.
- Use new `sendAlertSessionUpdate` function instead of `sendSingleAlert` when sending out Urgent Button Press Alerts. This will send the urgent messages using Push Notifications if it can
- Added a `db.clearTables` function that will delete everything in sessions, installations, notifications, and buttons tables in the right order so that we don't have to remember to do it properly in each integration test.

## Test Plan
- ✔️  Passes the test plan in https://github.com/bravetechnologycoop/brave-alert-lib/pull/18