### PR TITLE
No longer update Responded At when given an invalid incident category (CU-1ae1j60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ the code was deployed.
 - Updated `ALERT_STATE` to `CHATBOT_STATE`.
 - `POST /alert/designatedevice` also logs the given Responder Push ID (CU-10xfkhr).
 
+### Fixed
+
+- No longer updates a session's Responded At time if given an invalid incident category (CU-1ae1j60).
+
 ## [4.1.0] - 2021-07-26
 
 ### Added

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -127,7 +127,7 @@ class BraveAlerterConfigurator {
           session.fallBackAlertTwilioStatus = alertSession.fallbackReturnMessage
         }
 
-        if (alertSession.alertState === CHATBOT_STATE.WAITING_FOR_CATEGORY) {
+        if (alertSession.alertState === CHATBOT_STATE.WAITING_FOR_CATEGORY && session.respondedAt === null) {
           session.respondedAt = await db.getCurrentTime(client)
         }
 

--- a/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
@@ -20,9 +20,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
 
     await db.createInstallation('', this.installationResponderPhoneNumber, '{}', this.installationIncidentCategories, null, null)
     const installations = await db.getInstallations()
-    await db.createSession(installations[0].id, '', '701', '', 1, null)
-    const sessions = await db.getAllSessions()
-    const session = sessions[0]
+    const session = await db.createSession(installations[0].id, '', '701', '', 1, null)
     this.sessionId = session.id
     session.state = this.sessionState
     session.incidentType = this.sessionIncidentType

--- a/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
@@ -12,29 +12,27 @@ const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator.js')
 // Configure Chai
 use(sinonChai)
 
+const sandbox = sinon.createSandbox()
+
 describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', () => {
   beforeEach(() => {
     this.fakeCurrentTime = new Date('2020-12-25T10:09:08.000Z')
-    sinon.stub(db, 'getCurrentTime').returns(this.fakeCurrentTime)
-    sinon.stub(db, 'beginTransaction')
-    sinon.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
-    sinon.stub(db, 'getInstallationWithSessionId').returns({
+    sandbox.stub(db, 'getCurrentTime').returns(this.fakeCurrentTime)
+    sandbox.stub(db, 'beginTransaction')
+    sandbox.stub(db, 'getInstallationWithSessionId').returns({
       incidentCategories: ['Cat0', 'Cat1', 'Cat2'],
     })
-    sinon.stub(db, 'saveSession')
-    sinon.stub(db, 'commitTransaction')
+    sandbox.stub(db, 'saveSession')
+    sandbox.stub(db, 'commitTransaction')
   })
 
   afterEach(() => {
-    db.commitTransaction.restore()
-    db.saveSession.restore()
-    db.getInstallationWithSessionId.restore()
-    db.getSessionWithSessionId.restore()
-    db.beginTransaction.restore()
-    db.getCurrentTime.restore()
+    sandbox.restore()
   })
 
   it('if given alertState STARTED should update only alertState', async () => {
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
+
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
@@ -43,10 +41,12 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const expectedSession = createTestSessionState()
     expectedSession.state = CHATBOT_STATE.STARTED
 
-    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState WAITING_FOR_REPLY should update only alertState', async () => {
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
+
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
@@ -55,10 +55,14 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const expectedSession = createTestSessionState()
     expectedSession.state = CHATBOT_STATE.WAITING_FOR_REPLY
 
-    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
-  it('if given alertState WAITING_FOR_CATEGORY should update alertState and respondedAt', async () => {
+  it('if given alertState WAITING_FOR_CATEGORY and it has not already been responded to should update alertState and respondedAt', async () => {
+    const testSessionState = createTestSessionState()
+    testSessionState.respondedAt = null
+    sandbox.stub(db, 'getSessionWithSessionId').returns(testSessionState)
+
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
@@ -68,10 +72,30 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     expectedSession.state = CHATBOT_STATE.WAITING_FOR_CATEGORY
     expectedSession.respondedAt = this.fakeCurrentTime
 
-    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
+  })
+
+  it('if given alertState WAITING_FOR_CATEGORY and it has already been responded to should update alertState', async () => {
+    const testSessionState = createTestSessionState()
+    const testRespondedAtTime = new Date('2010-06-06T06:06:06.000Z')
+    testSessionState.respondedAt = testRespondedAtTime
+    sandbox.stub(db, 'getSessionWithSessionId').returns(testSessionState)
+
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_CATEGORY))
+
+    const expectedSession = createTestSessionState()
+    expectedSession.state = CHATBOT_STATE.WAITING_FOR_CATEGORY
+    expectedSession.respondedAt = testRespondedAtTime
+
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState WAITING_FOR_DETAILS should update only alertState', async () => {
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
+
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
@@ -80,10 +104,12 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const expectedSession = createTestSessionState()
     expectedSession.state = CHATBOT_STATE.WAITING_FOR_DETAILS
 
-    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState COMPLETED should update only alertState', async () => {
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
+
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
@@ -92,10 +118,12 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const expectedSession = createTestSessionState()
     expectedSession.state = CHATBOT_STATE.COMPLETED
 
-    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState and categoryKey should update alertState and category', async () => {
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
+
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
@@ -105,10 +133,12 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     expectedSession.state = CHATBOT_STATE.WAITING_FOR_DETAILS
     expectedSession.incidentType = 'Cat0'
 
-    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState and details should update alertState and details', async () => {
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
+
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
@@ -118,10 +148,12 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     expectedSession.state = CHATBOT_STATE.COMPLETED
     expectedSession.notes = 'fakeDetails'
 
-    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given only fallback return message should update only fallback return message', async () => {
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
+
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
@@ -130,6 +162,6 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const expectedSession = createTestSessionState()
     expectedSession.fallBackAlertTwilioStatus = 'fakeFallbackReturnMessage'
 
-    expect(db.saveSession).to.be.calledWith(expectedSession, sinon.any)
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 })


### PR DESCRIPTION
This is just a one-liner, but I took the opportunity to do some clean up in the session-related functions in `db.js` since they will be tested in this test plan and are sort of related to what I changed.

## Test plan
- :heavy_check_mark: Deploy to `chatbot-dev`
- :heavy_check_mark: Use Postman to simulate a button press and see the respondedAt value is `null`
   - :heavy_check_mark: Respond 'OK' and see the respondedAt value change to the current time on the Dashboard
   - :heavy_check_mark: Respond to the incident category question with a valid incident category and see the respondedAt value does not change
   - :heavy_check_mark: Respond to the incident category question with an invalid incident category and see the respondedAt value does not change
   - :heavy_check_mark: Respond to the incident details question and see the respondedAt value does not change
   - :heavy_check_mark: Do not respond 'OK' to the button press and see that the respondedAt value remains `null` after the reminder message and after the fallback message
