### PR TITLE
Add custom sound to push notifications by updating brave-alert-lib (CU-10xfkhr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## Unreleased
 
+### Added
+
+- Sound effects to push notifications (CU-10xfkhr).
+
 ### Changed
 
 - Allow releaseinfo changes on RPis (CU-1kxmhta).

--- a/server/.env.example
+++ b/server/.env.example
@@ -84,3 +84,8 @@ ONESIGNAL_APP_ID_TEST=guid-here
 # OneSignal App ID from OneSignal --> Settings --> Keys & IDs --> REST API Key
 ONESIGNAL_API_KEY=jumbleOfCharactersHere
 ONESIGNAL_API_KEY_TEST=jumbleOfCharactersHere
+
+# OneSignal Alert Android Category ID
+# Login to our OneSignal Account. Get this value from Settings --> Messaging --> Android Categories --> Alerts and Reminders --> Channel ID
+ONESIGNAL_ALERT_ANDROID_CATEGORY_ID=guid-here
+ONESIGNAL_ALERT_ANDROID_CATEGORY_ID_TEST=android-group-guid

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1052,8 +1052,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#35a46cac42fc746b4ee8a173364ff785c39f090d",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v6.0.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#e183981fb440b312b21bc1341b05a55e578eda58",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v6.1.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.18.3",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v6.0.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v6.1.0",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "express-session": "^1.15.6",


### PR DESCRIPTION
## Test Plan
- :heavy_check_mark: Deploy to `chatbot-dev`
- On Android
   - :heavy_check_mark: Custom sound used for push notifications when Alert is in the foreground
   - :heavy_check_mark: Custom sound used for push notifications when Alert App is closed
   - :heavy_check_mark: Custom sound used for push notifications when Alert App is in the background
   - :question: Custom sound stops when the the app is opened (this seems to work when I use the notification to open it, but not when I open it through the normal app)
- On iOS
 :heavy_check_mark: Custom sound used for push notifications when Alert is in the foreground
   - :x: Custom sound used for push notifications when Alert App is closed
   - :x: Custom sound used for push notifications when Alert App is in the background
   - :question: Custom sound stops when the the app is opened