### PR TITLE
Added firmware for range testing a single RB50 button CU-1hym8ja

### DIFF
--- a/particle-button-hub/project.properties
+++ b/particle-button-hub/project.properties
@@ -1,0 +1,2 @@
+name=boron-rb50-button-hub
+dependencies.CircularBuffer=1.3.3

--- a/particle-button-hub/src/BraveSensorProductionFirmware.ino
+++ b/particle-button-hub/src/BraveSensorProductionFirmware.ino
@@ -1,0 +1,41 @@
+/*
+ * Brave firmware state machine for single Boron
+ * written by Heidi Fedorak, Apr 2021
+*/
+
+#include "Particle.h"
+#include "rb50button.h"
+
+#define DEBUG_LEVEL LOG_LEVEL_INFO
+#define BRAVE_FIRMWARE_VERSION 3000 //see versioning notes in the readme
+#define BRAVE_PRODUCT_ID 14807 //14807 = beta units, 15054 = production units
+
+PRODUCT_ID(BRAVE_PRODUCT_ID); //you get this number off the particle console, see readme for instructions
+PRODUCT_VERSION(BRAVE_FIRMWARE_VERSION); //must be an int, see versioning notes above
+SYSTEM_THREAD(ENABLED);
+SerialLogHandler logHandler(WARN_LEVEL);
+
+unsigned long lastTime = 0;
+
+void setup() {
+  // enable reset reason
+  System.enableFeature(FEATURE_RESET_INFO);
+
+  // use external antenna on Boron
+  BLE.selectAntenna(BleAntennaType::EXTERNAL);
+  Particle.publishVitals(900);  //15 minutes
+}
+
+void loop() {
+
+    static bool initialized = false;
+      if(!initialized && Particle.connected()){ 
+            setupButtons();
+            initialized = true; 
+
+      }
+
+  if(initialized){
+      checkButtonsandPublish();
+  }
+}

--- a/particle-button-hub/src/rb50button.cpp
+++ b/particle-button-hub/src/rb50button.cpp
@@ -1,0 +1,110 @@
+#include "Particle.h"
+#include "rb50button.h"
+#include <queue>
+
+
+unsigned char previousControlByte = 0x00;
+os_queue_t bleQueue;
+
+
+//**********setup()******************
+
+void setupButtons(){
+
+	// Create a queue. Each element is an unsigned char, there are 25 elements. Last parameter is always 0.
+	os_queue_create(&bleQueue, sizeof(buttonData), 25, 0);
+	// Create the thread
+	new Thread("scanBLEThread", threadBLEScanner);
+
+}
+
+//**********loop()*******************
+
+void checkButtonsandPublish(){
+  static int initialButtonDataFlag = 1;
+  static buttonData currentButtonData = {"BUTTONADDRESS", 0x00, 0};
+  static buttonData previousButtonData = {"BUTTONADDRESS", 0x99, 0};
+
+  if (os_queue_take(bleQueue, &currentButtonData, 0, 0) == 0) {
+
+    if(initialButtonDataFlag){
+      initialButtonDataFlag = 0;
+      logAndPublishButtonData(currentButtonData);
+      previousButtonData = currentButtonData;
+    } 
+    else if(currentButtonData.controlByte == (previousButtonData.controlByte+0x01)){
+      logAndPublishButtonData(currentButtonData);
+      previousButtonData = currentButtonData;
+    }
+    else if (currentButtonData.controlByte > (previousButtonData.controlByte+0x01)){
+      logAndPublishButtonData(currentButtonData);
+      logAndPublishButtonWarning(currentButtonData);
+      previousButtonData = currentButtonData;
+    }
+    else if ((currentButtonData.controlByte == 0x00) && (previousButtonData.controlByte == 0xFF)){
+      logAndPublishButtonData(currentButtonData);
+      previousButtonData = currentButtonData;
+    }
+    else {
+      Log.info("no new data");
+    } // end publish if-else
+  }//end queue if 
+}
+
+void threadBLEScanner(void *param) {
+  
+  const unsigned int SCAN_RESULT_MAX = 10;
+  BleScanResult scanResults[SCAN_RESULT_MAX];
+  buttonData scanThreadButtonData;
+  unsigned char buttonAdvertisingData[BLE_MAX_ADV_DATA_LEN];
+  
+  //setting scan timeout (how long scan runs for) to 50ms = 5 centiseconds
+  //using millis() to measure, timeout(1) = 13-14 ms. timout(5) = 53-54ms
+  BLE.setScanTimeout(5);
+
+  while(true){
+    int count = BLE.scan(scanResults, SCAN_RESULT_MAX);
+
+    //loop over all devices found in the BLE scan
+    for (int i = 0; i < count; i++) {
+    
+      scanResults[i].advertisingData.get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buttonAdvertisingData, BLE_MAX_ADV_DATA_LEN);
+
+      String name = scanResults[i].advertisingData.deviceName();
+      unsigned char typeID = buttonAdvertisingData[4];
+      unsigned char rb50ID = 0x36;
+  
+      //if advertising data has device name "iSensor " and deviceType matching rb50 button, check it's control byte and add it to the queue
+      if(name == "iSensor " && typeID == rb50ID){
+
+        scanThreadButtonData.buttonAddress = scanResults[i].address.toString();;
+        scanThreadButtonData.controlByte = buttonAdvertisingData[6];
+        scanThreadButtonData.rssi = scanResults[i].rssi;
+
+        os_queue_put(bleQueue, (void *)&scanThreadButtonData, 0, 0);
+      }
+    }
+    
+    os_thread_yield();
+      
+  }//endwhile
+
+}
+
+void logAndPublishButtonData(buttonData currentButtonData){
+
+  char buttonPublishBuffer[128];
+
+  sprintf(buttonPublishBuffer, "{ \"address\": \"%s\", \"controlByte\": \"%02X\", \"rssi\": \"%d\" }", 
+          currentButtonData.buttonAddress.c_str(), currentButtonData.controlByte, currentButtonData.rssi);
+  Particle.publish("RB50 Data", buttonPublishBuffer, PRIVATE);
+}
+
+void logAndPublishButtonWarning(buttonData currentButtonData){
+
+  char buttonPublishBuffer[128];
+
+  sprintf(buttonPublishBuffer, "{ \"address\": \"%s\", \"controlByte\": \"%02X\", \"rssi\": \"%d\" }", 
+          currentButtonData.buttonAddress.c_str(), currentButtonData.controlByte, currentButtonData.rssi);
+  Particle.publish("RB50 Warning", buttonPublishBuffer, PRIVATE);
+}

--- a/particle-button-hub/src/rb50button.h
+++ b/particle-button-hub/src/rb50button.h
@@ -1,0 +1,25 @@
+#ifndef RB50BUTTON_H
+#define RB50BUTTON_H
+
+//************************global typedef aliases*********************************
+
+typedef struct buttonData {
+    String buttonAddress;
+    unsigned char controlByte;
+    int8_t rssi;
+
+} buttonData;
+
+void setupButtons();
+
+void checkButtonsandPublish();
+void logAndPublishButtonData(buttonData buttonData);
+void logAndPublishButtonWarning(buttonData buttonData);
+
+//threads
+void threadBLEScanner(void *param);
+
+void checkButtonsandPublish();
+
+
+#endif


### PR DESCRIPTION
Tested on a Boron with Device OS 2.2.0 and 2.3.0-rc. The firmware uses the device name and type to look for RB50s so you don't need to hardcode a single test buttons address. I noted some stability problems while using it, namely frequent errors like this:

ERROR: Failed to load session data from persistent storage

but unsure if they're related to the single Boron I was testing on. 

In order to handle multiple buttons, the main change that needs to happen is for us to store a hash table of button addresses and control bytes, and to do the checks in checkAndPublishButtons() with that table instead of a single "previousControlByte".

![image](https://user-images.githubusercontent.com/7051376/137602312-2a221ec1-aea9-4090-9cef-85f324c60c6c.png)

I would prefer to use a short name filter style strategy to scan instead of a MAX_LENGTH for the scan and then checking the name. This is only available for Particle OS 3+ and a bit out of scope
