### PR TITLE
Allow releaseinfo changes on RPis (CU-1kxmhta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## Unreleased
 
+### Changed
+
+- Allow releaseinfo changes on RPis (CU-1kxmhta).
+
 ## [5.0.0] - 2021-10-18
 
 ### Added

--- a/pairing-tool/setup_pi.sh
+++ b/pairing-tool/setup_pi.sh
@@ -6,7 +6,7 @@ if [[ $EUID > 0 ]]; then
   echo "this script needs sudo privelages to run correctly."
   exit 1
 else
-  apt update
+  apt update --allow-releaseinfo-change
   apt install -y vim nodejs npm
 
   # install stable version of node

--- a/pi/setup_pi.sh
+++ b/pi/setup_pi.sh
@@ -42,7 +42,7 @@ else
   rfkill unblock wifi
 
   # install dependencies with apt and pip3
-  apt update
+  apt update --allow-releaseinfo-change
   apt install -y darkstat python3-gpiozero autossh ssh parprouted dhcp-helper avahi-daemon python3-pip
   pip3 install python-daemon
 


### PR DESCRIPTION
- Raspian OS version has changed from Buster to something else. So now,
  Buster, the one that is on our devices, is considered `oldstable`
  instead of `stable`. This fix came from:
  https://forums.raspberrypi.com/viewtopic.php?t=318302

# Test Plan
- :heavy_check_mark: Run `apt update --allow-releaseinfo-change` manually on the Kye7e hub just to make sure that it works with `apt update` (when we did this during the last deployment, we used `apt-get update`)
- :heavy_check_mark: Make these change to `setup_pi.sh` file on Alvis 1R Hub (which was missed during the previous deployment because it was offline at the time) and manually run `sudo ./BraveButtons/pi/setup_pi.sh ./BraveButtons/pi/pi_config.ini` to make sure that the changes to the script will work
- :heavy_check_mark: Run the Ansible script on just Alvis 1R to make sure that it will work for subsequent deployment (`ansible-playbook -i ~/BraveButtonsConfig/ansible/inventory-prod.yaml  ~/BraveButtons/ops/update_pi_fleet.yaml --ask-vault-pass --limit alvis_pi_1R`)