### PR TITLE
setup_pi.yaml no longer triggers apt update using the apt module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ the code was deployed.
 ### Changed
 
 - Allow releaseinfo changes on RPis (CU-1kxmhta).
+- `setup_pi.yaml` no longer triggers `apt update` using the apt module since ansible doesn't support allowing releaseinfo changes.
 
 ### Removed
 

--- a/ops/setup_pi.yaml
+++ b/ops/setup_pi.yaml
@@ -40,12 +40,13 @@
         name: "OPENSSH_PUBLIC_KEY_HOLDER"
         public_key: "{{ OPENSSH_KEYPAIR_RETURN.public_key }}"
 
+    # don't use update_cache here since there is no way to use --allow-releaseinfo-change in ansible
+    # unless they merge this: https://github.com/ansible/ansible/pull/62824
     - name: install git
       become: yes
       apt:
         name: git
         state: present
-        update_cache: yes
 
     - name: clone BraveButtons git repo
       git:


### PR DESCRIPTION
ansible doesn't support allowing releaseinfo changes; apt update still runs eventually because of the setup script.