### PR TITLE
 Improve session and cookie security on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ the code was deployed.
 
 - Hub modification endpoints (rename, mute, hide) (CU-dgm1bj).
 
+### Security
+
+- Improved cookie/session handling.
+
 ## [5.0.0] - 2021-10-18
 
 ### Added

--- a/server/server.js
+++ b/server/server.js
@@ -148,6 +148,8 @@ app.use(
     resave: false,
     saveUninitialized: false,
     cookie: {
+      secure: !helpers.isTestEnvironment(),
+      httpOnly: true,
       expires: 24 * 60 * 60 * 1000,
     },
   }),
@@ -302,6 +304,7 @@ app.get('/buttons-data', sessionChecker, async (req, res) => {
 
 app.get('/logout', (req, res) => {
   if (req.session.user && req.cookies.user_sid) {
+    req.session.destroy()
     res.clearCookie('user_sid')
     res.redirect('/')
   } else {


### PR DESCRIPTION
This came up while I was testing https://github.com/bravetechnologycoop/BraveSensor/pull/137 . I was able to use Postman with the logged in cookie from the browser to download the CSV Export even after I had logged out in the browser.

- If users had a copy of an cookie, they could still use it
  to see the dashboard pages even after the user logs out
- Recommended to make cookies secure and httpOnly in
  https://expressjs.com/en/advanced/best-practice-security.html#use-cookies-securely

## Test Plan
- :heavy_check_mark:  Deploy to `chatbot-dev`
- :heavy_check_mark:  Use Postman to try to download the CSV Export using the cookie from the browser
   - :heavy_check_mark:  I'm able to download it when I'm logged in
   - :heavy_check_mark:  I'm unable to download it when I'm logged out