### PR TITLE
Changes during Norland Hub 2 provisioning (CU-vf96g1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ the code was deployed.
 ### Changed
 
 - Allow releaseinfo changes on RPis (CU-1kxmhta).
-- `setup_pi.yaml` no longer triggers `apt update` using the apt module since ansible doesn't support allowing releaseinfo changes.
+- `setup_pi.yaml` triggers `apt update` in its own step because ansible's apt doesn't support allowing releaseinfo changes.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 1. run `npm run lint`
 
-# How to set up a generic Raspberry Pi environment (for a Brave Hub or the pairing tool):
+# How to set up a generic Raspberry Pi environment (for a development environment Brave Hub or the pairing tool):
 
 1. use either Balena Etcher or Raspberry Pi Imager to flash the SD card with Raspbian Buster
 
@@ -69,9 +69,15 @@
 
 # How to set up a Brave Hub using Ansible
 
-1. follow the generic RPi setup instructions above
+1. use either Balena Etcher or Raspberry Pi Imager to flash the SD card with Raspbian Buster
 
-1. install ansible (see https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+1. create a file named `ssh` in the boot partition of the SD card
+
+1. install the SD card into the raspberry pi, connect it to power and ethernet
+
+1. plug the RPi into a router that you have admin access to and determine its IP address
+
+1. on your local machine, install ansible (see https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
 
 1. on your local machine, ensure that this repo (BraveButtons) and the config repo (BraveButtonsConfig) are present
 
@@ -89,15 +95,17 @@
 
 1. run the following mega-command:
 
-```
-ansible-playbook -i ./BraveButtonsConfig/ansible/<inventory file name> \
+   ```
+   ansible-playbook -i ./BraveButtonsConfig/ansible/<inventory file name> \
                  -i '<local IP address of the RPi>,' \
                  -e 'target_alias=<alias of new RPi in inventory>' \
                  ./BraveButtons/ops/setup_pi.yaml \
                  --ask-vault-pass
-```
+   ```
 
-1. ssh into the RPi, copy the system_id from `\usr\local\brave\system_id` and add it to the Button Config Google Sheet
+1. ssh into the RPi and restart the RPi by running `sudo reboot now`
+
+1. ssh into the RPi and copy the system_id from `/usr/local/brave/system_id` and add it to the Button Config Google Sheet
 
 1. add an entry for the new hub to the `hubs` table in the db
 

--- a/ops/setup_pi.yaml
+++ b/ops/setup_pi.yaml
@@ -40,6 +40,13 @@
         name: "OPENSSH_PUBLIC_KEY_HOLDER"
         public_key: "{{ OPENSSH_KEYPAIR_RETURN.public_key }}"
 
+    - name: update apt
+      become: yes
+      shell: apt update --allow-releaseinfo-change
+      args:
+        executable: /bin/bash
+        chdir: /home/pi
+
     # don't use update_cache here since there is no way to use --allow-releaseinfo-change in ansible
     # unless they merge this: https://github.com/ansible/ansible/pull/62824
     - name: install git


### PR DESCRIPTION
Some updates to the README and to `setup_pi.yaml` as we were going through the provisioning process for Norland Hub 2.

## Test plan
- :heavy_check_mark: Provision Norland Hub 2