### PR TITLE
Change master branch name to match preferred branching scheme (CU-mn5q4g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Please note that the date associated with a release is the date the code
-was committed to the `master` branch. This is not necessarily the date that
+was committed to the `main` branch. This is not necessarily the date that
 the code was deployed.
 
 ## [Unreleased]
@@ -24,6 +24,7 @@ the code was deployed.
 - `setup_pi.sh` sets the hostname in a more robust way (CU-40tzeq).
 - Updated `add_hubs.sh` to include an installation id foreign key (CU-vf8x83).
 - No longer required to type the certbot domain during deployment (CU-brhk3t).
+- Branching scheme (CU-mn5q4g).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BraveButtons [![Build Status](https://travis-ci.com/bravetechnologycoop/BraveButtons.svg?branch=master)](https://travis-ci.com/bravetechnologycoop/BraveButtons)
+# BraveButtons [![Build Status](https://travis-ci.com/bravetechnologycoop/BraveButtons.svg?branch=main)](https://travis-ci.com/bravetechnologycoop/BraveButtons)
 
 # How to set up a local server dev environment
 
@@ -187,27 +187,27 @@ making a new tag during step 2. This is essentially redeploying an older version
 
 1. on your local machine, in the `BraveButtons` repository:
 
-   1. pull the latest code ready for release: `git checkout master && git pull origin master`
+   1. pull the latest code ready for release: `git checkout main && git pull origin main`
 
    1. decide on an appropriate version number for the new version
 
    1. update CHANGELOG.md by moving everything in `Unreleased` to a section for the new version
 
-   1. make a new commit directly on `master` which only updates the changelog
+   1. make a new commit directly on `main` which only updates the changelog
 
    1. tag the new commit - for example, if the version number is v1.0.0, use `git tag v1.0.0`
 
-   1. push the new version to GitHub: `git push origin master --tags`
+   1. push the new version to GitHub: `git push origin main --tags`
 
-   1. update the `production` branch: `git checkout production && git merge master && git push origin production`
+   1. update the `production` branch: `git checkout production && git merge main && git push origin production`
 
 1. on your local machine, in the `BraveButtonsConfig` repository:
 
-   1. ensure you have the latest version of the code: `git pull origin master`
+   1. ensure you have the latest version of the code: `git pull origin main`
 
    1. tag the latest commit with the same version number used above, ie. `git tag v1.0.0`
 
-   1. update the `production` branch: `git checkout production && git merge master && git push origin production --tags`
+   1. update the `production` branch: `git checkout production && git merge main && git push origin production --tags`
 
 1. send a message to the `#buttons-aa-general` Slack channel letting everyone know that you are doing a deployment and to expect some downtime.
 

--- a/server/package.json
+++ b/server/package.json
@@ -54,5 +54,5 @@
   "bugs": {
     "url": "https://github.com/bravetechnologycoop/BraveButtons/issues"
   },
-  "homepage": "https://github.com/bravetechnologycoop/BraveButtons/tree/master/chatbot#readme"
+  "homepage": "https://github.com/bravetechnologycoop/BraveButtons"
 }


### PR DESCRIPTION
- Renamed `master` --> `main`
- Updated README and CHANGELOG accordingly
- Documentation here: https://app.clickup.com/2434616/v/dc/2a9hr-2261/2a9hr-4347
- Also fixed a 404 link in packages.json that had `master` in the URL

Once this pull request is approved, I will *not* merge it into `master`. Instead, I will 
1. Double-check that this branch is up-to-date with `master` (if not, then I'll rebase with `master`)
2. Update GitHub's default branch to be `main`
3. Change the target of all open pull requests from `master` to `main`
4. Delete the `master` branch

Once that is done, then the steps that I suggest everyone does on their local are:
1. Delete the `master` branch
2. Pull the `main` branch