### PR TITLE
setup_pi.sh sets the hostname in a more robust way (CU-40tzeq)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ the code was deployed.
 
 ## [Unreleased]
 
+
+### Changed
+
+- `setup_pi.sh` sets the hostname in a more robust way (CU-40tzeq).
+
 ## [6.1.0] - 2021-11-29
 
 ### Changed

--- a/pi/setup_pi.sh
+++ b/pi/setup_pi.sh
@@ -96,8 +96,9 @@ else
   chmod 700 /usr/local/brave
 
   # change the hostname according to the config
+  old_hostname=$(</etc/hostname)
   hosts_file=$(</etc/hosts)
-  hosts_file="${hosts_file//raspberrypi/$hostname}"
+  hosts_file="${hosts_file//$old_hostname/$hostname}"
   echo "$hosts_file" > /etc/hosts
   echo "$hostname" > /etc/hostname
 


### PR DESCRIPTION
this pull request changes `setup_pi.sh` so that the hostname can be repeatedly changed. the previous implementation would only work when changing the hostname from the default value of 'raspberrypi'.

thanks @trisapeace for the idea on how to implement this.

I tested this by manually running `setup_pi.sh` on a test hub while changing the hostname in `pi_config.ini`. each time the hostname was updated properly in both `/etc/hostname` and `/etc/hosts`. the hub was also able to connect to the internet and appeared normally on the heartbeat dashboard.