### PR TITLE
Fix flaky getActiveAlertsByAlertApiKey integration test

### DIFF
--- a/server/db/db.js
+++ b/server/db/db.js
@@ -644,7 +644,7 @@ async function getHistoricAlertsByAlertApiKey(alertApiKey, maxHistoricAlerts, ma
       WHERE i.alert_api_key = $1
       AND (
         s.state = $2
-        OR s.updated_at < now() - $3 * INTERVAL '1 millisecond'
+        OR s.updated_at <= now() - $3 * INTERVAL '1 millisecond'
       )
       ORDER BY s.created_at DESC
       LIMIT $4


### PR DESCRIPTION
- The `db.getHistoricAlertsByAlertApiKey` function compares
`maxTimeAgoInMillis` against the `updated_at` value in the DB. It's
possible that this test is running so fast that it has been less than
one millisecond since the `db.createSession` completed, in which case
we would get the wrong value back. So I changed the DB query to compare
<= instead of <. This will not make any real difference to the behaviour
in real life (because a 1ms difference doesn't really matter to humans)
but should make this test more reliable.