### PR TITLE
Make hub.installation_id NOT NULL in the database (CU-vf8x83)

### DIFF
--- a/server/db/018-sethubinstallationidtonotnull.sql
+++ b/server/db/018-sethubinstallationidtonotnull.sql
@@ -1,0 +1,22 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 18;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        ALTER TABLE hubs
+        ALTER COLUMN installation_id SET NOT NULL;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -15,3 +15,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USE
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/014-addrespondedattosessions.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/015-addnotifications.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/016-addresponderpushidtoinstallations.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER --set=sslmode=require -f ./db/018-sethubinstallationidtonotnull.sql


### PR DESCRIPTION
- This constraint will help us avoid human errors. We
  should never have a hub without an installation

Cannot be merged until after #123 is *DEPLOYED*.

## Test plan
- Run migration on my local database to check that it worked
- Deploy to Buttons Dev