### PR TITLE
Make the setup server script non-interactive (CU-brhk3t)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ the code was deployed.
 
 - Usage of deprecated `body-parser` module (CU-13kqxyt).
 - Usage of deprecated `moment` module for time-related code.
-- IP-specific firewall rules (CU-brhk3t).
+- IP-specific firewall rules in the server setup script (CU-brhk3t).
+- Interactive DB configuration of the initial installation in the server setup script (CU-brhk3t).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ the code was deployed.
 
 - Usage of deprecated `body-parser` module (CU-13kqxyt).
 - Usage of deprecated `moment` module for time-related code.
+- IP-specific firewall rules (CU-brhk3t).
 
 ### Fixed
 

--- a/server/setup_server.sh
+++ b/server/setup_server.sh
@@ -32,7 +32,7 @@ else
     ufw allow ssh
     ufw allow http
     ufw allow https
-    ufw enable
+    ufw --force enable  # needed to add '--force' to avoid interactive confirmation (https://askubuntu.com/questions/611749/how-to-run-ufw-without-interactive-mode)
 
     apt update
     apt install software-properties-common
@@ -43,10 +43,6 @@ else
     PATH=$PATH        # needed to set the new path for this version of node
     setcap cap_net_bind_service=+ep /usr/local/bin/node   # allows non-root to use port 443
     npm ci
-
-    echo "Please enter in order the name and responder phone number and one fallback phone number for the first installation (separated by a space):" 
-    echo "NOTE that this will have no effect if this script has already been run"
-    read installationName responderNumber fallbackNumber
 
     # Get the certbot certificate and choose option "1" to keep the existing certificate (as opposed option "2" to renew and replace it)
     printf "1" | certbot certonly --standalone -d $domain
@@ -82,7 +78,7 @@ else
     runuser -u brave -- pm2 stop ecosystem.config.js --env production
 
     # update the database
-    ./setup_postgresql.sh $installationName $responderNumber $fallbackNumber
+    ./setup_postgresql.sh
 
     # start a new process is started
     runuser -u brave -- pm2 start ecosystem.config.js --env production

--- a/server/setup_server.sh
+++ b/server/setup_server.sh
@@ -27,13 +27,9 @@ else
         fi
     done < $1
 
-    echo "please enter two IP addresses to allowlist for SSH (separated by a space):"
-    read firstIP secondIP
-
     ufw default deny incoming
     ufw default allow outgoing
-    ufw allow from $firstIP to any port 22
-    ufw allow from $secondIP to any port 22
+    ufw allow ssh
     ufw allow http
     ufw allow https
     ufw enable


### PR DESCRIPTION
## Test plan
- :heavy_check_mark:  Run on `chatbot-dev` without any keyboard entry
- :heavy_check_mark: After running, on `chatbot-dev`, see that:
   - :heavy_check_mark: Able to SSH from my normal IP
   - :heavy_check_mark: Able to SSH from a new IP (used a phone hot spot)
   - :heavy_check_mark: See port 22 open when running `sudo ufw status`
- :heavy_check_mark: On my local machine, delete my local database and run `setup_postgres.sql` without any parameters to see that it still works and that it puts a single dummy installation in the `installations` table