### PR TITLE
Add endpoint for RAK LoRa Buttons (CU-1xcw5vn)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ matrix:
         - SESSION_RESET_TIMEOUT_TEST=7200000
         - RADIO_BRIDGE_API_KEY_PRIMARY_TEST=primaryKey
         - RADIO_BRIDGE_API_KEY_SECONDARY_TEST=secondaryKey
+        - RAK_API_KEY_PRIMARY_TEST=rakKey1
+        - RAK_API_KEY_SECONDARY_TEST=rakKey2
 
       # setup database
       before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the code was deployed.
 ### Changed
 
 - Added missing rows to the `clients` table and started using them.
+- API endpoint for pressing a RAK LoRa button (CU-1xcw5vn).
 
 ## [7.0.0] - 2022-01-20
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -101,3 +101,11 @@ RADIO_BRIDGE_API_KEY_PRIMARY=123
 RADIO_BRIDGE_API_KEY_PRIMARY_TEST=123
 RADIO_BRIDGE_API_KEY_SECONDARY=123
 RADIO_BRIDGE_API_KEY_SECONDARY_TEST=123
+
+# Primary and secondary API keys used by RAK to send API calls to the Buttons server
+# Two keys are used to allow for seamless API key rotation
+# Get this from 1Password --> Brave Buttons Credentials --> AWS Lambda Function API key
+RAK_API_KEY_PRIMARY=123
+RAK_API_KEY_PRIMARY_TEST=123
+RAK_API_KEY_SECONDARY=123
+RAK_API_KEY_SECONDARY_TEST=123

--- a/server/rak.js
+++ b/server/rak.js
@@ -1,0 +1,64 @@
+// Third-party dependencies
+const Validator = require('express-validator')
+
+// In-house dependencies
+const { helpers } = require('brave-alert-lib')
+const db = require('./db/db')
+const buttonAlerts = require('./buttonAlerts')
+
+const rakApiKeys = [helpers.getEnvVar('RAK_API_KEY_PRIMARY'), helpers.getEnvVar('RAK_API_KEY_SECONDARY')]
+
+const EVENT_TYPE = {
+  BUTTON_PRESS: 'QQ==',
+}
+
+const validateButtonPress = [Validator.body(['devEui', 'payload']).notEmpty(), Validator.header(['authorization']).notEmpty()]
+
+async function handleButtonPress(req, res) {
+  try {
+    const validationErrors = Validator.validationResult(req).formatWith(helpers.formatExpressValidationErrors)
+
+    if (validationErrors.isEmpty()) {
+      const { devEui, payload } = req.body
+      const { authorization } = req.headers
+
+      // TODO Remove this after we are done testing the RAK buttons
+      helpers.log(JSON.stringify(req.body))
+
+      if (!rakApiKeys.includes(authorization)) {
+        helpers.logError(`INVALID RAK API key from '${devEui}' for a ${payload} payload`)
+        res.status(401).send()
+        return
+      }
+
+      if (payload === EVENT_TYPE.BUTTON_PRESS) {
+        const button = await db.getButtonWithSerialNumber(devEui)
+        if (button === null) {
+          const errorMessage = `Bad request to ${req.path}: DevEui is not registered: '${devEui}'`
+          helpers.logError(errorMessage)
+          res.status(400).send(`Bad request to ${req.path}: DevEui is not registered`)
+        } else {
+          await buttonAlerts.handleValidRequest(button, 1)
+
+          res.status(200).send()
+        }
+        // TODO } else if (eventType === EVENT_TYPE.HEARTBEAT) {
+      } else {
+        res.status(200).send()
+      }
+    } else {
+      const errorMessage = `Bad request to ${req.path}: ${validationErrors.array()}`
+      helpers.logError(errorMessage)
+      res.status(400).send(errorMessage)
+    }
+  } catch (err) {
+    helpers.logError(err)
+    res.status(500).send()
+  }
+}
+
+module.exports = {
+  EVENT_TYPE,
+  handleButtonPress,
+  validateButtonPress,
+}

--- a/server/routes.js
+++ b/server/routes.js
@@ -4,6 +4,7 @@ const express = require('express')
 // In-house dependencies
 const flic = require('./flic')
 const radiobridge = require('./radiobridge')
+const rak = require('./rak.js')
 const vitals = require('./vitals')
 
 const jsonBodyParser = express.json()
@@ -14,6 +15,7 @@ function configureRoutes(app) {
   app.post('/flic_button_press', flic.validateButtonPress, flic.handleButtonPress)
   app.post('/heartbeat', jsonBodyParser, vitals.handleHeartbeat)
   app.post('/radiobridge_button_press', jsonBodyParser, radiobridge.validateButtonPress, radiobridge.handleButtonPress)
+  app.post('/rak_button_press', jsonBodyParser, rak.validateButtonPress, rak.handleButtonPress)
 
   // TODO add the other routes
 }

--- a/server/test/integration/rakTest/handleButtonPressTest.js
+++ b/server/test/integration/rakTest/handleButtonPressTest.js
@@ -1,0 +1,240 @@
+// Third-party dependencies
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+const sinonChai = require('sinon-chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+
+// In-house dependencies
+const { helpers, factories } = require('brave-alert-lib')
+const buttonAlerts = require('../../../buttonAlerts')
+const db = require('../../../db/db')
+const { buttonDBFactory } = require('../../testingHelpers')
+const { server } = require('../../../server')
+
+chai.use(chaiHttp)
+chai.use(sinonChai)
+
+const expect = chai.expect
+const sandbox = sinon.createSandbox()
+
+const rakApiKeyPrimary = helpers.getEnvVar('RAK_API_KEY_PRIMARY')
+const rakApiKeySecondary = helpers.getEnvVar('RAK_API_KEY_SECONDARY')
+
+describe('rak.js integration tests: handleButtonpress', () => {
+  beforeEach(async () => {
+    await db.clearTables()
+
+    sandbox.spy(helpers, 'log')
+    sandbox.spy(helpers, 'logError')
+    sandbox.stub(buttonAlerts, 'handleValidRequest')
+  })
+
+  afterEach(async () => {
+    sandbox.restore()
+  })
+
+  describe('POST with empty devEui', () => {
+    beforeEach(async () => {
+      this.response = await chai.request(server).post('/rak_button_press').set('authorization', rakApiKeyPrimary).send({ payload: 'QQ==' })
+    })
+
+    it('should return 400', () => {
+      expect(this.response).to.have.status(400)
+    })
+
+    it('should log the error', () => {
+      expect(helpers.logError).to.be.calledWithExactly('Bad request to /rak_button_press: devEui (Invalid value)')
+    })
+
+    it('should not handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).not.to.be.called
+    })
+  })
+
+  describe('POST with empty payload', () => {
+    beforeEach(async () => {
+      this.response = await chai.request(server).post('/rak_button_press').set('authorization', rakApiKeyPrimary).send({ devEui: 'myDevEui' })
+    })
+
+    it('should return 400', () => {
+      expect(this.response).to.have.status(400)
+    })
+
+    it('should log the error', () => {
+      expect(helpers.logError).to.be.calledWithExactly('Bad request to /rak_button_press: payload (Invalid value)')
+    })
+
+    it('should not handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).not.to.be.called
+    })
+  })
+
+  describe('POST with empty authorization', () => {
+    beforeEach(async () => {
+      this.response = await chai.request(server).post('/rak_button_press').set('authorization', '').send({ devEui: 'myDevEui', payload: 'QQ==' })
+    })
+
+    it('should return 400', () => {
+      expect(this.response).to.have.status(400)
+    })
+
+    it('should log the error', () => {
+      expect(helpers.logError).to.be.calledWithExactly('Bad request to /rak_button_press: authorization (Invalid value)')
+    })
+
+    it('should not handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).not.to.be.called
+    })
+  })
+
+  describe('POST with invalid authorization', () => {
+    beforeEach(async () => {
+      this.response = await chai.request(server).post('/rak_button_press').set('authorization', 'x').send({ devEui: 'myDevEui', payload: 'QQ==' })
+    })
+
+    it('should return 401', () => {
+      expect(this.response).to.have.status(401)
+    })
+
+    it('should log the error', () => {
+      expect(helpers.logError).to.be.calledWithExactly(`INVALID RAK API key from 'myDevEui' for a QQ== payload`)
+    })
+
+    it('should not handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).not.to.be.called
+    })
+  })
+
+  describe('POST QQ== with primary API key for non-existent Button', () => {
+    beforeEach(async () => {
+      this.response = await chai
+        .request(server)
+        .post('/rak_button_press')
+        .set('authorization', rakApiKeyPrimary)
+        .send({ devEui: 'notMyDevEui', payload: 'QQ==' })
+    })
+
+    it('should return 400', () => {
+      expect(this.response).to.have.status(400)
+    })
+
+    it('should log the error', () => {
+      expect(helpers.logError).to.be.calledWithExactly(`Bad request to /rak_button_press: DevEui is not registered: 'notMyDevEui'`)
+    })
+
+    it('should not handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).not.to.be.called
+    })
+  })
+
+  describe('POST QQ== with primary API key for existing Button', () => {
+    beforeEach(async () => {
+      const buttonSerialNumber = '7bj2n3f7dsf23fad'
+      const client = await factories.clientDBFactory(db)
+      this.button = await buttonDBFactory(db, {
+        clientId: client.id,
+        buttonSerialNumber,
+      })
+
+      this.response = await chai
+        .request(server)
+        .post('/rak_button_press')
+        .set('authorization', rakApiKeyPrimary)
+        .send({ devEui: buttonSerialNumber, payload: 'QQ==' })
+    })
+
+    afterEach(async () => {
+      await db.clearTables()
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should not log any errors', () => {
+      expect(helpers.logError).not.to.be.called
+    })
+
+    it('should handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).to.be.calledWithExactly(this.button, 1)
+    })
+  })
+
+  describe('POST QQ== with secondary API key for existing Button', () => {
+    beforeEach(async () => {
+      const buttonSerialNumber = '7bj2n3f7dsf23fad'
+      const client = await factories.clientDBFactory(db)
+      this.button = await buttonDBFactory(db, {
+        clientId: client.id,
+        buttonSerialNumber,
+      })
+
+      this.response = await chai
+        .request(server)
+        .post('/rak_button_press')
+        .set('authorization', rakApiKeySecondary)
+        .send({ devEui: buttonSerialNumber, payload: 'QQ==' })
+    })
+
+    afterEach(async () => {
+      await db.clearTables()
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should not log any errors', () => {
+      expect(helpers.logError).not.to.be.called
+    })
+
+    it('should handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).to.be.calledWithExactly(this.button, 1)
+    })
+  })
+
+  describe('POST non-QQ== with primary API key', () => {
+    beforeEach(async () => {
+      this.response = await chai
+        .request(server)
+        .post('/rak_button_press')
+        .set('authorization', rakApiKeyPrimary)
+        .send({ devEui: 'myDevEui', payload: 'not_QQ==' })
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should not log any errors', () => {
+      expect(helpers.logError).not.to.be.called
+    })
+
+    it('should not handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).not.to.be.called
+    })
+  })
+
+  describe('POST non-QQ== with secondary API key', () => {
+    beforeEach(async () => {
+      this.response = await chai
+        .request(server)
+        .post('/rak_button_press')
+        .set('authorization', rakApiKeySecondary)
+        .send({ devEui: 'myDevEui', payload: 'not_QQ==' })
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should not log any errors', () => {
+      expect(helpers.logError).not.to.be.called
+    })
+
+    it('should not handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).not.to.be.called
+    })
+  })
+})


### PR DESCRIPTION
Add `POST /rak_button_press` endpoint for use with the RAK LoRa buttons and its tests.

## Test Plan
- Deploy to `chatbot-dev`
- Call it with a valid payload and the primary API key and  see the text messages appear
- Call it with a valid payload and the secondary API key and see the text messages appear
- Call it with an invalid payload
    - See no logs
    - Returns 200
- Call it with invalid authorization
   - See error log
   - Returns 401
- Call it with a DevEui that isn't in the DB and see an error log
    - See error log
    - Returns 400 