### PR TITLE
RAK Buttons 1, 2, and 4 no longer start the chatbot (CU-240e9z3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Changed
+
+- RAK Buttons 1, 2, and 4 no longer create a Button alert (CU-240e9z3).
+
 ## [8.0.0] - 2022-03-03
 
 ### Added

--- a/server/rak.js
+++ b/server/rak.js
@@ -40,15 +40,8 @@ async function handleButtonPress(req, res) {
       const button = await db.getButtonWithSerialNumber(devEui)
 
       if (event[0] === EVENT_TYPE.HEARTBEAT && button !== null) {
-        if (button !== null) {
-          await db.logButtonsVital(button.id, event[1])
-        }
-      } else if (
-        event[0] === EVENT_TYPE.BUTTON_PRESS_3 || // Button 3 is checked first because this is the most likely result
-        event[0] === EVENT_TYPE.BUTTON_PRESS_1 ||
-        event[0] === EVENT_TYPE.BUTTON_PRESS_2 ||
-        event[0] === EVENT_TYPE.BUTTON_PRESS_4
-      ) {
+        await db.logButtonsVital(button.id, event[1])
+      } else if (event[0] === EVENT_TYPE.BUTTON_PRESS_3) {
         if (button === null) {
           const errorMessage = `Bad request to ${req.path}: DevEui is not registered: '${devEui}'`
           helpers.logError(errorMessage)

--- a/server/test/integration/rakTest/handleButtonPressTest.js
+++ b/server/test/integration/rakTest/handleButtonPressTest.js
@@ -38,7 +38,7 @@ describe('rak.js integration tests: handleButtonpress', () => {
 
   describe('POST with empty devEui', () => {
     beforeEach(async () => {
-      this.response = await chai.request(server).post('/rak_button_press').set('authorization', rakApiKeyPrimary).send({ payload: 'QQ==' })
+      this.response = await chai.request(server).post('/rak_button_press').set('authorization', rakApiKeyPrimary).send({ payload: 'Qw==' })
     })
 
     it('should return 400', () => {
@@ -74,7 +74,7 @@ describe('rak.js integration tests: handleButtonpress', () => {
 
   describe('POST with empty authorization', () => {
     beforeEach(async () => {
-      this.response = await chai.request(server).post('/rak_button_press').set('authorization', '').send({ devEui: 'myDevEui', payload: 'QQ==' })
+      this.response = await chai.request(server).post('/rak_button_press').set('authorization', '').send({ devEui: 'myDevEui', payload: 'Qw==' })
     })
 
     it('should return 400', () => {
@@ -92,7 +92,7 @@ describe('rak.js integration tests: handleButtonpress', () => {
 
   describe('POST with invalid authorization', () => {
     beforeEach(async () => {
-      this.response = await chai.request(server).post('/rak_button_press').set('authorization', 'x').send({ devEui: 'myDevEui', payload: 'QQ==' })
+      this.response = await chai.request(server).post('/rak_button_press').set('authorization', 'x').send({ devEui: 'myDevEui', payload: 'Qw==' })
     })
 
     it('should return 401', () => {
@@ -100,7 +100,7 @@ describe('rak.js integration tests: handleButtonpress', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.be.calledWithExactly(`INVALID RAK API key from 'myDevEui' for a QQ== payload (decoded: A)`)
+      expect(helpers.logError).to.be.calledWithExactly(`INVALID RAK API key from 'myDevEui' for a Qw== payload (decoded: C)`)
     })
 
     it('should not handle the button press', () => {
@@ -117,12 +117,12 @@ describe('rak.js integration tests: handleButtonpress', () => {
         .send({ devEui: 'notMyDevEui', payload: 'QQ==' })
     })
 
-    it('should return 400', () => {
-      expect(this.response).to.have.status(400)
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
     })
 
-    it('should log the error', () => {
-      expect(helpers.logError).to.be.calledWithExactly(`Bad request to /rak_button_press: DevEui is not registered: 'notMyDevEui'`)
+    it('should not log an error', () => {
+      expect(helpers.logError).not.to.be.called
     })
 
     it('should not handle the button press', () => {
@@ -158,8 +158,8 @@ describe('rak.js integration tests: handleButtonpress', () => {
       expect(helpers.logError).not.to.be.called
     })
 
-    it('should handle the button press', () => {
-      expect(buttonAlerts.handleValidRequest).to.be.calledWithExactly(this.button, 1)
+    it('should not handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).not.to.be.called
     })
   })
 
@@ -187,12 +187,12 @@ describe('rak.js integration tests: handleButtonpress', () => {
       expect(this.response).to.have.status(200)
     })
 
-    it('should not log any errors', () => {
+    it('should not log an error', () => {
       expect(helpers.logError).not.to.be.called
     })
 
-    it('should handle the button press', () => {
-      expect(buttonAlerts.handleValidRequest).to.be.calledWithExactly(this.button, 1)
+    it('should not handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).not.to.be.called
     })
   })
 
@@ -253,16 +253,16 @@ describe('rak.js integration tests: handleButtonpress', () => {
       expect(this.response).to.have.status(200)
     })
 
-    it('should not log any errors', () => {
+    it('should not log an error', () => {
       expect(helpers.logError).not.to.be.called
     })
 
-    it('should handle the button press', () => {
-      expect(buttonAlerts.handleValidRequest).to.be.calledWithExactly(this.button, 1)
+    it('should not handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).not.to.be.called
     })
   })
 
-  describe('POST QQ== (Button 1) with secondary API key for existing Button', () => {
+  describe('POST Qw== (Button 3) with secondary API key for existing Button', () => {
     beforeEach(async () => {
       const buttonSerialNumber = '7bj2n3f7dsf23fad'
       const client = await factories.clientDBFactory(db)
@@ -275,7 +275,7 @@ describe('rak.js integration tests: handleButtonpress', () => {
         .request(server)
         .post('/rak_button_press')
         .set('authorization', rakApiKeySecondary)
-        .send({ devEui: buttonSerialNumber, payload: 'QQ==' })
+        .send({ devEui: buttonSerialNumber, payload: 'Qw==' })
     })
 
     afterEach(async () => {
@@ -360,7 +360,7 @@ describe('rak.js integration tests: handleButtonpress', () => {
         .request(server)
         .post('/rak_button_press')
         .set('authorization', rakApiKeyPrimary)
-        .send({ devEui: 'myDevEui', payload: 'not_QQ==' })
+        .send({ devEui: 'myDevEui', payload: 'not_Qw==' })
     })
 
     it('should return 200', () => {
@@ -382,7 +382,7 @@ describe('rak.js integration tests: handleButtonpress', () => {
         .request(server)
         .post('/rak_button_press')
         .set('authorization', rakApiKeySecondary)
-        .send({ devEui: 'myDevEui', payload: 'not_QQ==' })
+        .send({ devEui: 'myDevEui', payload: 'not_Qw==' })
     })
 
     it('should return 200', () => {


### PR DESCRIPTION
- This is to encourage putting the RAK Buttons into the Button
  Covers in the correct orientation. Hopefully someone would notice
  if they were put in incorrectly if the Button doesn't work

## Test Plan
- :heavy_check_mark: Deploy to Buttons Dev
- :heavy_check_mark: Use postman to send a Button 1, 2, and 4 press to see that it doesn't send a text message
- :heavy_check_mark: Use postman to send a Button 3 press to see that it does send a text message
- :heavy_check_mark: Use postman to send two Button 3 presses to see that it sends the Urgent text message
- Use a real RAK button and press Button 1, 2, and 4 to see which light pattern shows up