### PR TITLE
Add naming chatbot workflow (CU-24bxdpq)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the code was deployed.
 
 - RAK Buttons 1, 2, and 4 no longer create a Button alert (CU-240e9z3).
 
+### Removed
+
+- Stop storing the fallback responses in the DB.
+
 ## [8.0.0] - 2022-03-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Button Renaming chatbot workflow (CU-24bxdpq).
+
 ### Changed
 
 - RAK Buttons 1, 2, and 4 no longer create a Button alert (CU-240e9z3).

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -199,10 +199,21 @@ class BraveAlerterConfigurator {
     return count
   }
 
-  getReturnMessage(fromAlertState, toAlertState, incidentCategories) {
+  getReturnMessage(fromAlertState, toAlertState, incidentCategories, deviceName) {
     let returnMessage
 
     switch (fromAlertState) {
+      case CHATBOT_STATE.NAMING_STARTED:
+        if (toAlertState === CHATBOT_STATE.NAMING_POSTPONED) {
+          returnMessage = 'No problem. You will be asked to name this Brave Button again next time you press it.'
+        } else if (toAlertState === CHATBOT_STATE.NAMING_STARTED) {
+          returnMessage =
+            'Sorry, that name is invalid.\n\nTo give your Button a name now, please reply with the name.\nTo give your Button a name later, please reply with "Later".'
+        } else if (toAlertState === CHATBOT_STATE.NAMING_COMPLETED) {
+          returnMessage = `Great! This Brave Button is now called "${deviceName}".\n\nIf this is incorrect or if you want to change this name, please email clientsupport@brave.coop.`
+        }
+        break
+
       case CHATBOT_STATE.STARTED:
       case CHATBOT_STATE.WAITING_FOR_REPLY:
         returnMessage = this.createResponseStringFromIncidentCategories(incidentCategories)

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -123,10 +123,6 @@ class BraveAlerterConfigurator {
           session.notes = alertSession.details
         }
 
-        if (alertSession.fallbackReturnMessage) {
-          session.fallBackAlertTwilioStatus = alertSession.fallbackReturnMessage
-        }
-
         if (alertSession.alertState === CHATBOT_STATE.WAITING_FOR_CATEGORY && session.respondedAt === null) {
           session.respondedAt = await db.getCurrentTime(pgClient)
         }

--- a/server/SessionState.js
+++ b/server/SessionState.js
@@ -1,6 +1,6 @@
 class SessionState {
   // prettier-ignore
-  constructor(id, clientId, buttonId, unit, phoneNumber, state, numPresses, createdAt, updatedAt, incidentType, notes, fallBackAlertTwilioStatus, buttonBatteryLevel, respondedAt) {
+  constructor(id, clientId, buttonId, unit, phoneNumber, state, numPresses, createdAt, updatedAt, incidentType, notes, buttonBatteryLevel, respondedAt) {
     this.id = id
     this.clientId = clientId
     this.buttonId = buttonId
@@ -12,7 +12,6 @@ class SessionState {
     this.updatedAt = updatedAt
     this.incidentType = incidentType
     this.notes = notes
-    this.fallBackAlertTwilioStatus = fallBackAlertTwilioStatus
     this.buttonBatteryLevel = buttonBatteryLevel
     this.respondedAt = respondedAt
   }

--- a/server/audit-ci.json
+++ b/server/audit-ci.json
@@ -1,4 +1,4 @@
 {
   "high": true,
-  "allowlist": [1002373]
+  "allowlist": []
 }

--- a/server/buttonAlerts.js
+++ b/server/buttonAlerts.js
@@ -31,27 +31,22 @@ async function handleValidRequest(button, numPresses, batteryLevel) {
     let currentSession = await db.getUnrespondedSessionWithButtonId(button.buttonId, pgClient)
     const currentTime = await db.getCurrentTime(pgClient)
 
-    if (batteryLevel !== undefined && batteryLevel >= 0 && batteryLevel <= 100) {
-      if (currentSession === null || currentTime - currentSession.updatedAt >= helpers.getEnvVar('SESSION_RESET_TIMEOUT')) {
-        currentSession = await db.createSession(
-          button.client.id,
-          button.buttonId,
-          button.unit,
-          button.phoneNumber,
-          numPresses,
-          batteryLevel,
-          null,
-          pgClient,
-        )
-      } else {
-        currentSession.incrementButtonPresses(numPresses)
-        currentSession.updateBatteryLevel(batteryLevel)
-        await db.saveSession(currentSession, pgClient)
-      }
-    } else if (currentSession === null || currentTime - currentSession.updatedAt >= helpers.getEnvVar('SESSION_RESET_TIMEOUT')) {
-      currentSession = await db.createSession(button.client.id, button.buttonId, button.unit, button.phoneNumber, numPresses, null, null, pgClient)
+    if (currentSession === null || currentTime - currentSession.updatedAt >= helpers.getEnvVar('SESSION_RESET_TIMEOUT')) {
+      currentSession = await db.createSession(
+        button.client.id,
+        button.buttonId,
+        button.unit,
+        button.phoneNumber,
+        numPresses,
+        batteryLevel !== undefined && batteryLevel >= 0 && batteryLevel <= 100 ? batteryLevel : null,
+        null,
+        pgClient,
+      )
     } else {
       currentSession.incrementButtonPresses(numPresses)
+      if (batteryLevel !== undefined && batteryLevel >= 0 && batteryLevel <= 100) {
+        currentSession.updateBatteryLevel(batteryLevel)
+      }
       await db.saveSession(currentSession, pgClient)
     }
 

--- a/server/buttonAlerts.js
+++ b/server/buttonAlerts.js
@@ -29,7 +29,7 @@ async function handleValidRequest(button, numPresses, batteryLevel) {
     }
 
     // Need to check the Button's name again inside the transaction to avoid a race condition
-    const buttonIsNotNamed = (await db.getButtonWithSerialNumber(button.buttonSerialNumber, pgClient)).unit === '_NEW'
+    const isUnnamedDevice = helpers.isUnnamedDevice((await db.getButtonWithSerialNumber(button.buttonSerialNumber, pgClient)).unit)
 
     let currentSession = await db.getUnrespondedSessionWithButtonId(button.buttonId, pgClient)
     const currentTime = await db.getCurrentTime(pgClient)
@@ -43,7 +43,7 @@ async function handleValidRequest(button, numPresses, batteryLevel) {
         numPresses,
         batteryLevel !== undefined && batteryLevel >= 0 && batteryLevel <= 100 ? batteryLevel : null,
         null,
-        buttonIsNotNamed ? CHATBOT_STATE.NAMING_STARTED : CHATBOT_STATE.STARTED,
+        isUnnamedDevice ? CHATBOT_STATE.NAMING_STARTED : CHATBOT_STATE.STARTED,
         null,
         null,
         pgClient,
@@ -58,7 +58,7 @@ async function handleValidRequest(button, numPresses, batteryLevel) {
 
     const client = await db.getClientWithId(currentSession.clientId, pgClient)
 
-    if (buttonIsNotNamed) {
+    if (isUnnamedDevice) {
       const alertInfo = {
         sessionId: currentSession.id,
         toPhoneNumber: client.responderPhoneNumber,

--- a/server/db/024_removefallbackalerttwiliostatus.sql
+++ b/server/db/024_removefallbackalerttwiliostatus.sql
@@ -1,0 +1,22 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 24;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        ALTER TABLE sessions
+        DROP COLUMN fallback_alert_twilio_status;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -497,16 +497,28 @@ async function getSessionWithSessionId(sessionId, pgClient) {
   return null
 }
 
-async function createSession(clientId, buttonId, unit, phoneNumber, numPresses, buttonBatteryLevel, respondedAt, pgClient) {
+async function createSession(
+  clientId,
+  buttonId,
+  unit,
+  phoneNumber,
+  numPresses,
+  buttonBatteryLevel,
+  respondedAt,
+  chatbotState,
+  incidentType,
+  notes,
+  pgClient,
+) {
   try {
     const results = await helpers.runQuery(
       'createSession',
       `
-      INSERT INTO sessions (client_id, button_id, unit, phone_number, state, num_presses, button_battery_level, responded_at) 
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      INSERT INTO sessions (client_id, button_id, unit, phone_number, state, num_presses, button_battery_level, responded_at, incident_type, notes) 
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
       RETURNING *
       `,
-      [clientId, buttonId, unit, phoneNumber, CHATBOT_STATE.STARTED, numPresses, buttonBatteryLevel, respondedAt],
+      [clientId, buttonId, unit, phoneNumber, chatbotState, numPresses, buttonBatteryLevel, respondedAt, incidentType, notes],
       pool,
       pgClient,
     )

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -27,7 +27,7 @@ types.setTypeParser(types.builtins.NUMERIC, value => parseFloat(value))
 
 function createSessionFromRow(r) {
   // prettier-ignore
-  return new SessionState(r.id, r.client_id, r.button_id, r.unit, r.phone_number, r.state, r.num_presses, r.created_at, r.updated_at, r.incident_type, r.notes, r.fallback_alert_twilio_status, r.button_battery_level, r.responded_at)
+  return new SessionState(r.id, r.client_id, r.button_id, r.unit, r.phone_number, r.state, r.num_presses, r.created_at, r.updated_at, r.incident_type, r.notes, r.button_battery_level, r.responded_at)
 }
 
 function createClientFromRow(r) {
@@ -543,8 +543,8 @@ async function saveSession(session, pgClient) {
       'saveSessionUpdate',
       `
       UPDATE sessions
-      SET client_id = $1, button_id = $2, unit = $3, phone_number = $4, state = $5, num_presses = $6, incident_type = $7, notes = $8, fallback_alert_twilio_status = $9, button_battery_level = $10, responded_at = $11
-      WHERE id = $12
+      SET client_id = $1, button_id = $2, unit = $3, phone_number = $4, state = $5, num_presses = $6, incident_type = $7, notes = $8, button_battery_level = $9, responded_at = $10
+      WHERE id = $11
       `,
       [
         session.clientId,
@@ -555,7 +555,6 @@ async function saveSession(session, pgClient) {
         session.numPresses,
         session.incidentType,
         session.notes,
-        session.fallBackAlertTwilioStatus,
         session.buttonBatteryLevel,
         session.respondedAt,
         session.id,
@@ -1162,7 +1161,7 @@ async function getDataForExport(pgClient) {
         TO_CHAR(s.updated_at, 'yyyy-MM-dd HH24:mi:ss') AS "Last Session Activity",
         s.incident_type AS "Session Incident Type",
         s.notes as "Session Notes",
-        s.fallback_alert_twilio_status AS "Fallback Alert Status (Twilio)",
+        "No longer used" AS "Fallback Alert Status (Twilio)",
         s.button_battery_level AS "Button Battery Level",
         TO_CHAR(r.created_at, 'yyyy-MM-dd HH24:mi:ss') AS "Date Button Created",
         TO_CHAR(r.updated_at, 'yyyy-MM-dd HH24:mi:ss') AS "Button Last Updated",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1599,47 +1599,46 @@
       "dev": true
     },
     "@sentry/core": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.18.0.tgz",
-      "integrity": "sha512-I3iQVfMWHXR/LtevJg83aD7UAiUBLz1xAW8y3gd5lJej96UNv/4TbCmKZumYnEJMXf8EcFlg8t48W0Bl1GxhEg==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.2.tgz",
+      "integrity": "sha512-yu1R3ewBT4udmB4v7sc4biQZ0Z0rfB9+TzB5ZKoCftbe6kqXjFMMaFRYNUF9HicVldKAsBktgkWw3+yfqGkw/A==",
       "requires": {
-        "@sentry/hub": "6.18.0",
-        "@sentry/minimal": "6.18.0",
-        "@sentry/types": "6.18.0",
-        "@sentry/utils": "6.18.0",
+        "@sentry/hub": "6.19.2",
+        "@sentry/minimal": "6.19.2",
+        "@sentry/types": "6.19.2",
+        "@sentry/utils": "6.19.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.18.0.tgz",
-      "integrity": "sha512-E2GrrNcidyT67ONU3btHO5vyS1bPQNdWqC09sUc1F3q/nQyvc7L2W09TKY2veaMZQtC9EU760fTG1hMmgGwPmw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.2.tgz",
+      "integrity": "sha512-W7KCgNBgdBIMagOxy5J5KQPe+maYxSqfE8a5ncQ3R8BcZDQEKnkW/1FplNbfRLZqA/tL/ndKb7pTPqVtzsbARw==",
       "requires": {
-        "@sentry/types": "6.18.0",
-        "@sentry/utils": "6.18.0",
+        "@sentry/types": "6.19.2",
+        "@sentry/utils": "6.19.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.18.0.tgz",
-      "integrity": "sha512-QkkWOhX3NMycUNLj96thMQ0BclmfxE2VdDf9ZqRkvdFzxI1FVY5NEArqD4wtlrCIoYN1ioAYrvdb48/BTuGung==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.2.tgz",
+      "integrity": "sha512-ClwxKm77iDHET7kpzv1JvzDx1er5DoNu+EUjst0kQzARIrXvu9xuZuE2/CnBWycQWqw8o3HoGoKz65uIhsUCzQ==",
       "requires": {
-        "@sentry/hub": "6.18.0",
-        "@sentry/types": "6.18.0",
+        "@sentry/hub": "6.19.2",
+        "@sentry/types": "6.19.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.18.0.tgz",
-      "integrity": "sha512-gESzabgJSs3uuOpZQ4tdI3V0k1nl9fqToTHOJDMeOqusHYfY/wlRDtdvN0Qn+vdvkGI/Eh3u8RnFQXCzkbCAbQ==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.2.tgz",
+      "integrity": "sha512-Z1qREpTpYHxaeWjc1zMUk8ZTAp1WbxMiI2TVNc+a14DVT19Z2xNXb06MiRfeLgNc9lVGdmzR62dPmMBjVgPJYg==",
       "requires": {
-        "@sentry/core": "6.18.0",
-        "@sentry/hub": "6.18.0",
-        "@sentry/tracing": "6.18.0",
-        "@sentry/types": "6.18.0",
-        "@sentry/utils": "6.18.0",
+        "@sentry/core": "6.19.2",
+        "@sentry/hub": "6.19.2",
+        "@sentry/types": "6.19.2",
+        "@sentry/utils": "6.19.2",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -1647,28 +1646,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.18.0.tgz",
-      "integrity": "sha512-thwVrYT+ba58h6F6Im4t+JH9o+7H+75ribkeTgM7NRhNuiGajlXNmb37Dh9gP5Iy76jNV8GATy4cOcuVc7P1jA==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.19.2.tgz",
+      "integrity": "sha512-rGoPpP1JIAxdq5bzrww0XuNVr6yn7RN6/wUcaxf6CAvklKvDx+q28WTGlZLGTZ/3un8Rv6i1FZFZOXizgnVnrg==",
       "requires": {
-        "@sentry/hub": "6.18.0",
-        "@sentry/minimal": "6.18.0",
-        "@sentry/types": "6.18.0",
-        "@sentry/utils": "6.18.0",
+        "@sentry/hub": "6.19.2",
+        "@sentry/minimal": "6.19.2",
+        "@sentry/types": "6.19.2",
+        "@sentry/utils": "6.19.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.0.tgz",
-      "integrity": "sha512-SypDwXL1URE/XLkP4Ve+pFs41e+2OUYZ0lCimNreQQv46//pFXxP3LwU9Tc0Az4ZfxXnGiwofvt73XyBq9VpRQ=="
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.2.tgz",
+      "integrity": "sha512-XO5qmVBdTs+7PdCz7fAwn1afWxSnRE2KLBFg5/vOdKosPSSHsSHUURSkxiEZc2QsR+JpRB4AeQ26AkIRX38qTg=="
     },
     "@sentry/utils": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.18.0.tgz",
-      "integrity": "sha512-mKegOabkAjoUHfokjI5oi3CMez5GD3xXOrBFcLVc9GFDXCgNMdYnHyEn/mmy8PikFdGHxZ3oI/16ZGU22wi5aw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.2.tgz",
+      "integrity": "sha512-2DQQ2OJaxjtyxGq5FmMlqb6hptsqMs2xoBiVRMkTS/rvyTrk1oQdKZ8ePwjtgX3nJ728ni3IXIyXV+vfGp4EBw==",
       "requires": {
-        "@sentry/types": "6.18.0",
+        "@sentry/types": "6.19.2",
         "tslib": "^1.9.3"
       }
     },
@@ -2132,8 +2131,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#21a91075ef2d5d45d5ac6d93d200478aa51f524b",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v6.6.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#2dbf563f76b39dc5dbb61bc7b88ce28029c40670",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#td-add-naming-chatbot",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2131,7 +2131,7 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#2dbf563f76b39dc5dbb61bc7b88ce28029c40670",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#280899dcc34e10f260eb050e67dcd957400ba696",
       "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#td-add-naming-chatbot",
       "requires": {
         "@sentry/node": "^6.2.5",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2131,7 +2131,7 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#280899dcc34e10f260eb050e67dcd957400ba696",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#ad3f03b72588672b80cc2bfa36c8b1387814d6c6",
       "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#td-add-naming-chatbot",
       "requires": {
         "@sentry/node": "^6.2.5",
@@ -4277,9 +4277,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mocha": {
@@ -5058,9 +5058,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
           "dev": true
         },
         "ansi-styles": {

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "@aws-sdk/client-iot-wireless": "^3.50.0",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v6.6.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#td-add-naming-chatbot",
     "cookie-parser": "^1.4.3",
     "express": "^4.16.4",
     "express-session": "^1.15.6",

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -22,3 +22,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USE
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/021-addbuttonvitals.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/022-addgatewaystable.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/023-removehubhidden.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/024_removefallbackalerttwiliostatus.sql

--- a/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
@@ -6,6 +6,7 @@ const { afterEach, beforeEach, describe, it } = require('mocha')
 const { CHATBOT_STATE, AlertSession, factories } = require('brave-alert-lib')
 const db = require('../../../db/db')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
+const { sessionDBFactory } = require('../../testingHelpers')
 
 describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneNumber', () => {
   beforeEach(async () => {
@@ -27,12 +28,16 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
       alertApiKey: null,
       responderPushId: null,
     })
-    const session = await db.createSession(client.id, '', '701', this.sessionToPhoneNumber, 1)
+    const session = await sessionDBFactory(db, {
+      clientId: client.id,
+      unit: '701',
+      numPresses: 1,
+      phoneNumber: this.sessionToPhoneNumber,
+      chatbotState: this.sessionState,
+      incidentType: this.sessionIncidentType,
+      notes: this.sessionNotes,
+    })
     this.sessionId = session.id
-    session.state = this.sessionState
-    session.incidentType = this.sessionIncidentType
-    session.notes = this.sessionNotes
-    await db.saveSession(session)
   })
 
   afterEach(async () => {

--- a/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionBySessionidAndAlertApiKeyTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionBySessionidAndAlertApiKeyTest.js
@@ -6,6 +6,7 @@ const { afterEach, beforeEach, describe, it } = require('mocha')
 const { CHATBOT_STATE, AlertSession, factories } = require('brave-alert-lib')
 const db = require('../../../db/db')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
+const { sessionDBFactory } = require('../../testingHelpers')
 
 describe('BraveAlerterConfigurator.js integration tests: getAlertSessionBySessionidAndAlertApiKey', () => {
   beforeEach(async () => {
@@ -28,12 +29,16 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionBySessio
       alertApiKey: this.alertApiKey,
       responderPushId: null,
     })
-    const session = await db.createSession(client.id, '', '701', this.sessionToPhoneNumber, 1)
+    const session = await sessionDBFactory(db, {
+      clientId: client.id,
+      unit: '701',
+      numPresses: 1,
+      phoneNumber: this.sessionToPhoneNumber,
+      chatbotState: this.sessionState,
+      incidentType: this.sessionIncidentType,
+      notes: this.sessionNotes,
+    })
     this.sessionId = session.id
-    session.state = this.sessionState
-    session.incidentType = this.sessionIncidentType
-    session.notes = this.sessionNotes
-    await db.saveSession(session)
   })
 
   afterEach(async () => {

--- a/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
@@ -6,6 +6,7 @@ const { afterEach, beforeEach, describe, it } = require('mocha')
 const { CHATBOT_STATE, AlertSession, factories } = require('brave-alert-lib')
 const db = require('../../../db/db')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
+const { sessionDBFactory } = require('../../testingHelpers')
 
 describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () => {
   beforeEach(async () => {
@@ -26,12 +27,15 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
       alertApiKey: null,
       responderPushId: null,
     })
-    const session = await db.createSession(client.id, '', '701', '', 1, null)
+    const session = await sessionDBFactory(db, {
+      clientId: client.id,
+      chatbotState: this.sessionState,
+      incidentType: this.sessionIncidentType,
+      notes: this.sessionNotes,
+      unit: '701',
+      numPresses: 1,
+    })
     this.sessionId = session.id
-    session.state = this.sessionState
-    session.incidentType = this.sessionIncidentType
-    session.notes = this.sessionNotes
-    await db.saveSession(session)
   })
 
   afterEach(async () => {

--- a/server/test/integration/dbTest/getActiveAlertsByAlertApiKeyTest.js
+++ b/server/test/integration/dbTest/getActiveAlertsByAlertApiKeyTest.js
@@ -99,7 +99,6 @@ describe('db.js integration tests: getActiveAlertsByAlertApiKey', () => {
           new Date(),
           null,
           '',
-          '',
           this.session.buttonBatteryLevel,
           this.respondedAt,
         ),

--- a/server/test/integration/dbTest/getActiveAlertsByAlertApiKeyTest.js
+++ b/server/test/integration/dbTest/getActiveAlertsByAlertApiKeyTest.js
@@ -3,10 +3,9 @@ const { expect } = require('chai')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 
 // In-house dependencies
-const { CHATBOT_STATE, ALERT_TYPE, factories } = require('brave-alert-lib')
+const { CHATBOT_STATE, factories } = require('brave-alert-lib')
 const db = require('../../../db/db')
-const SessionState = require('../../../SessionState')
-const { buttonDBFactory } = require('../../testingHelpers')
+const { buttonDBFactory, sessionDBFactory } = require('../../testingHelpers')
 
 describe('db.js integration tests: getActiveAlertsByAlertApiKey', () => {
   describe('if there are no clients with the given Alert API Key', () => {
@@ -19,7 +18,11 @@ describe('db.js integration tests: getActiveAlertsByAlertApiKey', () => {
         buttonId: '51b8be5678bf5ade9bf6a5958b2a4a45',
         clientId: client.id,
       })
-      await db.createSession(client.id, button.buttonId, 'unit', 'phoneNumber', 5, 95, new Date())
+      await sessionDBFactory(db, {
+        clientId: client.id,
+        buttonId: button.buttonId,
+        chatbotState: CHATBOT_STATE.STARTED,
+      })
     })
 
     afterEach(async () => {
@@ -45,7 +48,11 @@ describe('db.js integration tests: getActiveAlertsByAlertApiKey', () => {
         buttonId: '51b8be5678bf5ade9bf6a5958b2a4a45',
         clientId: client.id,
       })
-      await db.createSession(client.id, button.buttonId, 'unit', 'phoneNumber', 5, 95, new Date())
+      await sessionDBFactory(db, {
+        clientId: client.id,
+        buttonId: button.buttonId,
+        chatbotState: CHATBOT_STATE.STARTED,
+      })
 
       // Insert a single client with no sessions that matches the Alert API Key that we ask for
       this.alertApiKey = 'alertApiKey'
@@ -82,27 +89,16 @@ describe('db.js integration tests: getActiveAlertsByAlertApiKey', () => {
       })
 
       // Insert a single session for that API key
-      this.incidentType = ALERT_TYPE.BUTTONS_URGENT
       this.numPresses = 6
       this.respondedAt = new Date('2021-01-20T06:20:19.000Z')
-      this.session = await db.createSession(client.id, this.button.buttonId, this.button.unit, 'phoneNumber', this.numPresses, 95, this.respondedAt)
-      await db.saveSession(
-        new SessionState(
-          this.session.id,
-          this.session.clientId,
-          this.session.buttonId,
-          this.session.unit,
-          this.session.phoneNumber,
-          CHATBOT_STATE.WAITING_FOR_CATEGORY,
-          this.numPresses,
-          this.session.createdAt,
-          new Date(),
-          null,
-          '',
-          this.session.buttonBatteryLevel,
-          this.respondedAt,
-        ),
-      )
+      this.session = await sessionDBFactory(db, {
+        clientId: client.id,
+        buttonId: this.button.buttonId,
+        unit: this.button.unit,
+        numPresses: this.numPresses,
+        respondedAt: this.respondedAt,
+        chatbotState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
+      })
     })
 
     afterEach(async () => {
@@ -140,7 +136,12 @@ describe('db.js integration tests: getActiveAlertsByAlertApiKey', () => {
         clientId: client.id,
         unit: 'unit1',
       })
-      this.session = await db.createSession(client.id, button.buttonId, button.unit, 'phoneNumber', '1', 95, new Date('2021-01-20T06:20:19.000Z'))
+      this.session = await sessionDBFactory(db, {
+        clientId: client.id,
+        buttonId: button.buttonId,
+        unit: button.unit,
+        respondedAt: new Date('2021-01-20T06:20:19.000Z'),
+      })
     })
 
     afterEach(async () => {
@@ -218,7 +219,12 @@ describe('db.js integration tests: getActiveAlertsByAlertApiKey', () => {
         clientId: client.id,
         unit: 'unit1',
       })
-      this.session = await db.createSession(client.id, button.buttonId, button.unit, 'phoneNumber', '1', 95, new Date('2021-01-20T06:20:19.000Z'))
+      this.session = await sessionDBFactory(db, {
+        clientId: client.id,
+        buttonId: button.buttonId,
+        unit: button.unit,
+        respondedAt: new Date('2021-01-20T06:20:19.000Z'),
+      })
     })
 
     afterEach(async () => {

--- a/server/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
+++ b/server/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
@@ -99,7 +99,6 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
           new Date(),
           this.incidentType,
           '',
-          '',
           this.session.buttonBatteryLevel,
           this.respondedAt,
         ),

--- a/server/test/integration/serverTest.js
+++ b/server/test/integration/serverTest.js
@@ -760,23 +760,5 @@ describe('Chatbot server', () => {
       expect(sessions[0].unit).to.deep.equal('2')
       expect(sessions[0].numPresses).to.deep.equal(1)
     })
-
-    it('should send a message to the fallback phone number if enough time has passed without a response', async () => {
-      const response = await chai
-        .request(server)
-        .post(`/flic_button_press?apikey=${validApiKey}`)
-        .set('button-serial-number', unit1SerialNumber)
-        .send()
-
-      expect(response).to.have.status(200)
-      await helpers.sleep(4000)
-      const sessions = await db.getAllSessionsWithButtonId(unit1UUID)
-      expect(sessions.length).to.equal(1)
-      expect(sessions[0].state, 'state after reminder timeout has elapsed').to.deep.equal(CHATBOT_STATE.WAITING_FOR_REPLY)
-      expect(sessions[0].fallBackAlertTwilioStatus).to.not.be.null
-      expect(sessions[0].fallBackAlertTwilioStatus).to.not.equal('failed, ')
-      expect(sessions[0].fallBackAlertTwilioStatus).to.not.equal('undelivered, ')
-      expect(sessions[0].fallBackAlertTwilioStatus).to.be.oneOf(['queued', 'sent', 'delivered'])
-    })
   })
 })

--- a/server/test/testingHelpers.js
+++ b/server/test/testingHelpers.js
@@ -1,7 +1,24 @@
 // In-house dependencies
-const { factories } = require('brave-alert-lib')
+const { factories, CHATBOT_STATE } = require('brave-alert-lib')
 const SessionState = require('../SessionState')
 const Hub = require('../Hub')
+
+async function sessionDBFactory(db, overrides = {}) {
+  const session = await db.createSession(
+    overrides.clientId !== undefined ? overrides.clientId : 'fakeClientId',
+    overrides.buttonId !== undefined ? overrides.buttonId : 'fakeButtonId',
+    overrides.unit !== undefined ? overrides.unit : '305',
+    overrides.phoneNumber !== undefined ? overrides.phoneNumber : '+12223334444',
+    overrides.numPresses !== undefined ? overrides.numPresses : 1,
+    overrides.buttonBatteryLevel !== undefined ? overrides.buttonBatteryLevel : 66,
+    overrides.respondedAt !== undefined ? overrides.respondedAt : new Date('2022-01-02T03:04:05.123Z'),
+    overrides.chatbotState !== undefined ? overrides.chatbotState : CHATBOT_STATE.COMPLETED,
+    overrides.incidentType !== undefined ? overrides.incidentType : 'Fake incident type',
+    overrides.notes !== undefined ? overrides.notes : 'Fake notes',
+  )
+
+  return session
+}
 
 function sessionFactory(overrides = {}) {
   return new SessionState(
@@ -53,5 +70,6 @@ function hubFactory(overrides = {}) {
 module.exports = {
   buttonDBFactory,
   hubFactory,
+  sessionDBFactory,
   sessionFactory,
 }

--- a/server/test/testingHelpers.js
+++ b/server/test/testingHelpers.js
@@ -3,22 +3,21 @@ const { factories } = require('brave-alert-lib')
 const SessionState = require('../SessionState')
 const Hub = require('../Hub')
 
-function createTestSessionState() {
+function sessionFactory(overrides = {}) {
   return new SessionState(
-    'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc',
-    'fakeClientId',
-    'fakeButtonId',
-    'fakeUnit',
-    'fakePhone',
-    'fakeState',
-    'fakeNumPresses',
-    'fakeCreatedAt',
-    'fakeUpdatedAt',
-    '1',
-    'fakeNotes',
-    'fakeFallbackTwilioState',
-    null,
-    new Date('2000-06-06T00:53:53.000Z'),
+    overrides.id !== undefined ? overrides.id : 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc',
+    overrides.clientId !== undefined ? overrides.clientId : 'fakeClientId',
+    overrides.buttonid !== undefined ? overrides.buttonId : 'fakeButtonId',
+    overrides.unit !== undefined ? overrides.unit : 'fakeUnit',
+    overrides.phoneNumber !== undefined ? overrides.phoneNumber : 'fakePhone',
+    overrides.state !== undefined ? overrides.state : 'fakeState',
+    overrides.numPresses !== undefined ? overrides.numPresses : 'fakeNumPresses',
+    overrides.createdAt !== undefined ? overrides.createdAt : 'fakeCreatedAt',
+    overrides.updatedAt !== undefined ? overrides.updatedAt : 'fakeUpdatedAt',
+    overrides.incidentType !== undefined ? overrides.incidentType : '1',
+    overrides.notes !== undefined ? overrides.notes : 'fakeNotes',
+    overrides.buttonBatteryLevel !== undefined ? overrides.buttonBatteryLevel : null,
+    overrides.respondedAt !== undefined ? overrides.respondedAt : new Date('2000-06-06T00:53:53.000Z'),
   )
 }
 
@@ -52,7 +51,7 @@ function hubFactory(overrides = {}) {
 }
 
 module.exports = {
-  createTestSessionState,
   buttonDBFactory,
   hubFactory,
+  sessionFactory,
 }

--- a/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
@@ -6,7 +6,7 @@ const sinonChai = require('sinon-chai')
 
 const { CHATBOT_STATE, AlertSession } = require('brave-alert-lib')
 const db = require('../../../db/db.js')
-const { createTestSessionState } = require('../../testingHelpers.js')
+const { sessionFactory } = require('../../testingHelpers.js')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator.js')
 
 // Configure Chai
@@ -31,136 +31,108 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
   })
 
   it('if given alertState STARTED should update only alertState', async () => {
-    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
-
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(sessionFactory({ id: sessionId }))
+
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
     await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.STARTED))
 
-    const expectedSession = createTestSessionState()
+    const expectedSession = sessionFactory()
     expectedSession.state = CHATBOT_STATE.STARTED
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState WAITING_FOR_REPLY should update only alertState', async () => {
-    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
-
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(sessionFactory({ id: sessionId }))
+
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
     await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_REPLY))
 
-    const expectedSession = createTestSessionState()
-    expectedSession.state = CHATBOT_STATE.WAITING_FOR_REPLY
+    const expectedSession = sessionFactory({ id: sessionId, state: CHATBOT_STATE.WAITING_FOR_REPLY })
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState WAITING_FOR_CATEGORY and it has not already been responded to should update alertState and respondedAt', async () => {
-    const testSessionState = createTestSessionState()
-    testSessionState.respondedAt = null
-    sandbox.stub(db, 'getSessionWithSessionId').returns(testSessionState)
-
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(sessionFactory({ id: sessionId, respondedAt: null }))
+
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
     await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_CATEGORY))
 
-    const expectedSession = createTestSessionState()
-    expectedSession.state = CHATBOT_STATE.WAITING_FOR_CATEGORY
-    expectedSession.respondedAt = this.fakeCurrentTime
+    const expectedSession = sessionFactory({ id: sessionId, state: CHATBOT_STATE.WAITING_FOR_CATEGORY, respondedAt: this.fakeCurrentTime })
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState WAITING_FOR_CATEGORY and it has already been responded to should update alertState', async () => {
-    const testSessionState = createTestSessionState()
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const testRespondedAtTime = new Date('2010-06-06T06:06:06.000Z')
-    testSessionState.respondedAt = testRespondedAtTime
+    const testSessionState = sessionFactory({ id: sessionId, respondedAt: testRespondedAtTime })
     sandbox.stub(db, 'getSessionWithSessionId').returns(testSessionState)
 
-    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
     await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_CATEGORY))
 
-    const expectedSession = createTestSessionState()
-    expectedSession.state = CHATBOT_STATE.WAITING_FOR_CATEGORY
-    expectedSession.respondedAt = testRespondedAtTime
+    const expectedSession = sessionFactory({ id: sessionId, state: CHATBOT_STATE.WAITING_FOR_CATEGORY, respondedAt: testRespondedAtTime })
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState WAITING_FOR_DETAILS should update only alertState', async () => {
-    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
-
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(sessionFactory({ id: sessionId }))
+
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
     await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_DETAILS))
 
-    const expectedSession = createTestSessionState()
-    expectedSession.state = CHATBOT_STATE.WAITING_FOR_DETAILS
+    const expectedSession = sessionFactory({ id: sessionId, state: CHATBOT_STATE.WAITING_FOR_DETAILS })
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState COMPLETED should update only alertState', async () => {
-    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
-
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(sessionFactory({ id: sessionId }))
+
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
     await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.COMPLETED))
 
-    const expectedSession = createTestSessionState()
-    expectedSession.state = CHATBOT_STATE.COMPLETED
+    const expectedSession = sessionFactory({ id: sessionId, state: CHATBOT_STATE.COMPLETED })
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState and categoryKey should update alertState and category', async () => {
-    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
-
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(sessionFactory({ id: sessionId }))
+
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
     await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_DETAILS, '0'))
 
-    const expectedSession = createTestSessionState()
-    expectedSession.state = CHATBOT_STATE.WAITING_FOR_DETAILS
-    expectedSession.incidentType = 'Cat0'
+    const expectedSession = sessionFactory({ id: sessionId, state: CHATBOT_STATE.WAITING_FOR_DETAILS, incidentType: 'Cat0' })
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
   it('if given alertState and details should update alertState and details', async () => {
-    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
-
     const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(sessionFactory({ id: sessionId }))
+
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
     await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.COMPLETED, undefined, 'fakeDetails'))
 
-    const expectedSession = createTestSessionState()
-    expectedSession.state = CHATBOT_STATE.COMPLETED
-    expectedSession.notes = 'fakeDetails'
-
-    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
-  })
-
-  it('if given only fallback return message should update only fallback return message', async () => {
-    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSessionState())
-
-    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
-    const braveAlerterConfigurator = new BraveAlerterConfigurator()
-    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, undefined, undefined, undefined, 'fakeFallbackReturnMessage'))
-
-    const expectedSession = createTestSessionState()
-    expectedSession.fallBackAlertTwilioStatus = 'fakeFallbackReturnMessage'
+    const expectedSession = sessionFactory({ id: sessionId, state: CHATBOT_STATE.COMPLETED, notes: 'fakeDetails' })
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })

--- a/server/test/unit/BraveAlerterConfiguratorTest/getReturnMessageTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/getReturnMessageTest.js
@@ -14,57 +14,112 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessage', () => {
   })
 
   it('should get message when STARTED => WAITING_FOR_REPLY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.STARTED, CHATBOT_STATE.WAITING_FOR_REPLY, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage(
+      CHATBOT_STATE.STARTED,
+      CHATBOT_STATE.WAITING_FOR_REPLY,
+      ['Cat0', 'Cat1'],
+      'funNewName',
+    )
     expect(returnMessage).to.equal(
       'Now that you have responded, please reply with the number that best describes the incident:\n0 - Cat0\n1 - Cat1\n',
     )
   })
 
   it('should get message when STARTED => WAITING_FOR_CATEGORY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.STARTED, CHATBOT_STATE.WAITING_FOR_CATEGORY, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage(
+      CHATBOT_STATE.STARTED,
+      CHATBOT_STATE.WAITING_FOR_CATEGORY,
+      ['Cat0', 'Cat1'],
+      'funNewName',
+    )
     expect(returnMessage).to.equal(
       'Now that you have responded, please reply with the number that best describes the incident:\n0 - Cat0\n1 - Cat1\n',
     )
   })
 
   it('should get message when WAITING_FOR_REPLY => WAITING_FOR_CATEGORY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.WAITING_FOR_REPLY, CHATBOT_STATE.WAITING_FOR_CATEGORY, [
-      'Cat0',
-      'Cat1',
-    ])
+    const returnMessage = this.alertStateMachine.getReturnMessage(
+      CHATBOT_STATE.WAITING_FOR_REPLY,
+      CHATBOT_STATE.WAITING_FOR_CATEGORY,
+      ['Cat0', 'Cat1'],
+      'funNewName',
+    )
     expect(returnMessage).to.equal(
       'Now that you have responded, please reply with the number that best describes the incident:\n0 - Cat0\n1 - Cat1\n',
     )
   })
 
   it('should get message when WAITING_FOR_CATEGORY => WAITING_FOR_CATEGORY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.WAITING_FOR_CATEGORY, CHATBOT_STATE.WAITING_FOR_CATEGORY, [
-      'Cat0',
-      'Cat1',
-    ])
+    const returnMessage = this.alertStateMachine.getReturnMessage(
+      CHATBOT_STATE.WAITING_FOR_CATEGORY,
+      CHATBOT_STATE.WAITING_FOR_CATEGORY,
+      ['Cat0', 'Cat1'],
+      'funNewName',
+    )
     expect(returnMessage).to.equal("Sorry, the incident type wasn't recognized. Please try again.")
   })
 
   it('should get message when WAITING_FOR_CATEGORY => WAITING_FOR_DETAILS', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.WAITING_FOR_CATEGORY, CHATBOT_STATE.WAITING_FOR_DETAILS, [
-      'Cat0',
-      'Cat1',
-    ])
+    const returnMessage = this.alertStateMachine.getReturnMessage(
+      CHATBOT_STATE.WAITING_FOR_CATEGORY,
+      CHATBOT_STATE.WAITING_FOR_DETAILS,
+      ['Cat0', 'Cat1'],
+      'funNewName',
+    )
     expect(returnMessage).to.equal('Thank you. If you like, you can reply with any further details about the incident.')
   })
 
   it('should get message when WAITING_FOR_DETAILS => COMPLETED', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.WAITING_FOR_DETAILS, CHATBOT_STATE.COMPLETED, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage(
+      CHATBOT_STATE.WAITING_FOR_DETAILS,
+      CHATBOT_STATE.COMPLETED,
+      ['Cat0', 'Cat1'],
+      'funNewName',
+    )
     expect(returnMessage).to.equal("Thank you. This session is now complete. (You don't need to respond to this message.)")
   })
 
   it('should get message when COMPLETED => COMPLETED', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.COMPLETED, CHATBOT_STATE.COMPLETED, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.COMPLETED, CHATBOT_STATE.COMPLETED, ['Cat0', 'Cat1'], 'funNewName')
     expect(returnMessage).to.equal("There is no active session for this button. (You don't need to respond to this message.)")
   })
 
+  it('should get message when NAMING_STARTED => NAMING_STARTED', () => {
+    const returnMessage = this.alertStateMachine.getReturnMessage(
+      CHATBOT_STATE.NAMING_STARTED,
+      CHATBOT_STATE.NAMING_STARTED,
+      ['Cat0', 'Cat1'],
+      'funNewName',
+    )
+    expect(returnMessage).to.equal(
+      'Sorry, that name is invalid.\n\nTo give your Button a name now, please reply with the name.\nTo give your Button a name later, please reply with "Later".',
+    )
+  })
+
+  it('should get message when NAMING_STARTED => NAMING_POSTPONED', () => {
+    const returnMessage = this.alertStateMachine.getReturnMessage(
+      CHATBOT_STATE.NAMING_STARTED,
+      CHATBOT_STATE.NAMING_POSTPONED,
+      ['Cat0', 'Cat1'],
+      'funNewName',
+    )
+    expect(returnMessage).to.equal('No problem. You will be asked to name this Brave Button again next time you press it.')
+  })
+
+  it('should get message when NAMING_STARTED => NAMING_COMPLETED', () => {
+    const returnMessage = this.alertStateMachine.getReturnMessage(
+      CHATBOT_STATE.NAMING_STARTED,
+      CHATBOT_STATE.NAMING_COMPLETED,
+      ['Cat0', 'Cat1'],
+      'funNewName',
+    )
+    expect(returnMessage).to.equal(
+      'Great! This Brave Button is now called "funNewName".\n\nIf this is incorrect or if you want to change this name, please email clientsupport@brave.coop.',
+    )
+  })
+
   it('should get default message if given something funky', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage('something funky', CHATBOT_STATE.COMPLETED, ['Cat0', 'Cat1'])
+    const returnMessage = this.alertStateMachine.getReturnMessage('something funky', CHATBOT_STATE.COMPLETED, ['Cat0', 'Cat1'], 'funNewName')
     expect(returnMessage).to.equal(
       'Thank you for responding. Unfortunately, we have encountered an error in our system and will deal with it shortly.',
     )

--- a/server/test/unit/SessionStateTest.js
+++ b/server/test/unit/SessionStateTest.js
@@ -1,37 +1,43 @@
 const chai = require('chai')
 
 const expect = chai.expect
-const beforeEach = require('mocha').beforeEach
 const describe = require('mocha').describe
 const it = require('mocha').it
-const CHATBOT_STATE = require('brave-alert-lib').CHATBOT_STATE
 
-const SessionState = require('../../SessionState.js')
+const { sessionFactory } = require('../testingHelpers.js')
 
-describe('SessionState class', () => {
-  const sessionId = '12345'
-  const clientId = '67890'
-  const buttonId = '12345'
-  const unit = '1'
-  const phoneNumber = '+14206666969'
-  const createdAt = Date()
-  const updatedAt = Date()
+describe('SessionState.js unit tests: ', () => {
+  describe('incrementButtonPresses', () => {
+    it('should increment the number of button presses by 1', () => {
+      const session = sessionFactory({
+        numPresses: 4,
+      })
 
-  let state
+      session.incrementButtonPresses(1)
 
-  beforeEach(() => {
-    state = new SessionState(sessionId, clientId, buttonId, unit, phoneNumber, CHATBOT_STATE.STARTED, 1, createdAt, updatedAt, null, null)
+      expect(session.numPresses).to.equal(4 + 1)
+    })
+
+    it('should increment the number of button presses by more than 1', () => {
+      const session = sessionFactory({
+        numPresses: 4,
+      })
+
+      session.incrementButtonPresses(3)
+
+      expect(session.numPresses).to.equal(4 + 3)
+    })
   })
 
-  it('should start off with 1 button press', () => {
-    expect(state).to.have.property('numPresses')
-    expect(state.numPresses).to.deep.equal(1)
-  })
+  describe('updateBatteryLevel', () => {
+    it('should update the button battery level', () => {
+      const session = sessionFactory({
+        buttonBatteryLevel: 20,
+      })
 
-  it('should increment properly', () => {
-    state.incrementButtonPresses(1)
-    expect(state.numPresses).to.deep.equal(2)
-    state.incrementButtonPresses(2)
-    expect(state.numPresses).to.deep.equal(4)
+      session.updateBatteryLevel(45)
+
+      expect(session.buttonBatteryLevel).to.equal(45)
+    })
   })
 })


### PR DESCRIPTION
- Added Button naming chatbot flow
- Updated dependencies for security reasons
- Removed the fallback Twilio response column from the `sessions` table and no longer store this data because we weren't using it and it is not planned to be stored in the shared DB schema

## Test plan:
- Deploy to Buttons Dev
- Automated tests pass
- CSV export
   - Shows "No longer used" in the Twilio column (did this so that it doesn't break any automated reports generated from the CSV)
- Push Button 3 for a button with `unit = '_NEW'`
   - See NAMING_STARTED status in Dashboard
   - Reply with a non-empty, non-'Later' name
      - Unit goes in the DB
      - See NAMING_COMPLETED status in Dashboard
      - See Responded_at and updated_at updated in Dashboard
      - Next Button push starts the normal chatbot with that name
   - Reply with an empty name
      - Get back message saying it is invalid and to try again
      - See NAMING_STARTED still in Dashboard
      - See updated_at and responded_at not change in Dashboard
      - Trying again works
   - Reply with a '_NEW' name
      - Get back message saying it is invalid and to try again
      - See NAMING_STARTED still in Dashboard
      - See updated_at and responded_at not change in Dashboard
      - Trying again works
   - Reply with a 'later' name
      - Get message back saying they can rename next time they push the button
      - See NAMING_POSTPONED in Dashboard
      - See updated_at and responded_at change in Dashboard
      - Next Button push starts the Naming chatbot again
   - Push Button 3 for the same Button again less than the session reset threshold
      - Nothing
   - Push Button 3 for the same Button again more than the session reset threshold
      - No reminder message 
      - No fallback message
      - Starts a new Session in the Dashboard with NAMING_STARTED status in the Dashboard
- Regression:
   - Normal button press with replies
   - Urgent button
   - Normal button press without replying (reminder and fallback)
      - Doesn't store the fallback Twilio responses in the DB