### PR TITLE
getGatewayStats will return `null` if there is LastUplinkReceivedAt (CU-2dm6j58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Changed
+
+- If the Last Uplink for a gateway is undefined, return `null` (CU-2dm6j58).
+
 ## [8.2.0] - 2022-06-02
 
 ### Changed

--- a/server/aws.js
+++ b/server/aws.js
@@ -25,7 +25,7 @@ async function getGatewayStats(gatewayId) {
       }),
     )
 
-    return new Date(stats.LastUplinkReceivedAt)
+    return stats.LastUplinkReceivedAt !== undefined ? new Date(stats.LastUplinkReceivedAt) : null
   } catch (e) {
     helpers.log(`Error getting gateways vitals for "${gatewayId}": ${e}`)
   }


### PR DESCRIPTION
- This seems to happen after 3 months of gateway inactivity. So we
  need to cover this case
- It also means that we'll be able to add new rows to `gateways`
  before we've the gateway connects to AWS for the first time, this
  could be useful as we speed up Buttons provisioning

## Test Plan
- :heavy_check_mark: Deploy to Dev
- :heavy_check_mark: When it checks the vitals of a gateway that has no Last Uplink At timestamp in AWS
   - :heavy_check_mark: Does not log a row in `gateways_vitals`
   - :heavy_check_mark: Does not log an error
   - :heavy_check_mark: Does not send an error to Sentry
- :heavy_check_mark: When it checks the vitals of a gateway that does have a Last Uplink At  timestamp in AWS
   - :heavy_check_mark: Logs a row in `gateways_vitals`
   - :heavy_check_mark: Does not log an error
   - :heavy_check_mark: Does not send an error to Sentry