### PR TITLE
Stops texts from completing older sessions (CU-q37bbk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the code was deployed.
 
 - If the Last Uplink for a gateway is undefined, return `null` (CU-2dm6j58).
 
+### Fixed
+
+- Text messages sent to the chatbot only interact with the most recent session (CU-q37bbk).
+
 ## [8.2.0] - 2022-06-02
 
 ### Changed

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -68,7 +68,7 @@ class BraveAlerterConfigurator {
     let alertSession = null
 
     try {
-      const session = await db.getMostRecentIncompleteSessionWithPhoneNumber(toPhoneNumber)
+      const session = await db.getMostRecentSessionWithPhoneNumber(toPhoneNumber)
       if (session === null) {
         return null
       }

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -248,19 +248,18 @@ async function getUnrespondedSessionWithButtonId(buttonId, pgClient) {
   return null
 }
 
-async function getMostRecentIncompleteSessionWithPhoneNumber(phoneNumber, pgClient) {
+async function getMostRecentSessionWithPhoneNumber(phoneNumber, pgClient) {
   try {
     const results = await helpers.runQuery(
-      'getMostRecentIncompleteSessionWithPhoneNumber',
+      'getMostRecentSessionWithPhoneNumber',
       `
       SELECT *
       FROM sessions
       WHERE phone_number = $1
-      AND state != $2
       ORDER BY created_at DESC
       LIMIT 1
       `,
-      [phoneNumber, CHATBOT_STATE.COMPLETED],
+      [phoneNumber],
       pool,
       pgClient,
     )
@@ -1289,7 +1288,7 @@ module.exports = {
   getClientWithId,
   getClientWithSessionId,
   getGateways,
-  getMostRecentIncompleteSessionWithPhoneNumber,
+  getMostRecentSessionWithPhoneNumber,
   getNewNotificationsCountByAlertApiKey,
   getPool,
   getRecentButtonsVitals,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2225,46 +2225,46 @@
       "dev": true
     },
     "@sentry/core": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.6.tgz",
-      "integrity": "sha512-biEotGRr44/vBCOegkTfC9rwqaqRKIpFljKGyYU6/NtzMRooktqOhjmjmItNCMRknArdeaQwA8lk2jcZDXX3Og==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
+      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
       "requires": {
-        "@sentry/hub": "6.19.6",
-        "@sentry/minimal": "6.19.6",
-        "@sentry/types": "6.19.6",
-        "@sentry/utils": "6.19.6",
+        "@sentry/hub": "6.19.7",
+        "@sentry/minimal": "6.19.7",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.6.tgz",
-      "integrity": "sha512-PuEOBZxvx3bjxcXmWWZfWXG+orojQiWzv9LQXjIgroVMKM/GG4QtZbnWl1hOckUj7WtKNl4hEGO2g/6PyCV/vA==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
+      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
       "requires": {
-        "@sentry/types": "6.19.6",
-        "@sentry/utils": "6.19.6",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.6.tgz",
-      "integrity": "sha512-T1NKcv+HTlmd8EbzUgnGPl4ySQGHWMCyZ8a8kXVMZOPDzphN3fVIzkYzWmSftCWp0rpabXPt9aRF2mfBKU+mAQ==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
+      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
       "requires": {
-        "@sentry/hub": "6.19.6",
-        "@sentry/types": "6.19.6",
+        "@sentry/hub": "6.19.7",
+        "@sentry/types": "6.19.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.6.tgz",
-      "integrity": "sha512-kHQMfsy40ZxxdS9zMPmXCOOLWOJbQj6/aVSHt/L1QthYcgkAi7NJQNXnQIPWQDe8eP3DfNIWM7dc446coqjXrQ==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
+      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
       "requires": {
-        "@sentry/core": "6.19.6",
-        "@sentry/hub": "6.19.6",
-        "@sentry/types": "6.19.6",
-        "@sentry/utils": "6.19.6",
+        "@sentry/core": "6.19.7",
+        "@sentry/hub": "6.19.7",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -2272,28 +2272,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.19.6.tgz",
-      "integrity": "sha512-STZdlEtTBqRmPw6Vjkzi/1kGkGPgiX0zdHaSOhSeA2HXHwx7Wnfu7veMKxtKWdO+0yW9QZGYOYqp0GVf4Swujg==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.19.7.tgz",
+      "integrity": "sha512-ol4TupNnv9Zd+bZei7B6Ygnr9N3Gp1PUrNI761QSlHtPC25xXC5ssSD3GMhBgyQrcvpuRcCFHVNNM97tN5cZiA==",
       "requires": {
-        "@sentry/hub": "6.19.6",
-        "@sentry/minimal": "6.19.6",
-        "@sentry/types": "6.19.6",
-        "@sentry/utils": "6.19.6",
+        "@sentry/hub": "6.19.7",
+        "@sentry/minimal": "6.19.7",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.6.tgz",
-      "integrity": "sha512-QH34LMJidEUPZK78l+Frt3AaVFJhEmIi05Zf8WHd9/iTt+OqvCHBgq49DDr1FWFqyYWm/QgW/3bIoikFpfsXyQ=="
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
+      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg=="
     },
     "@sentry/utils": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.6.tgz",
-      "integrity": "sha512-fAMWcsguL0632eWrROp/vhPgI7sBj/JROWVPzpabwVkm9z3m1rQm6iLFn4qfkZL8Ozy6NVZPXOQ7EXmeU24byg==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
+      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
       "requires": {
-        "@sentry/types": "6.19.6",
+        "@sentry/types": "6.19.7",
         "tslib": "^1.9.3"
       }
     },
@@ -2689,6 +2689,14 @@
       "integrity": "sha512-1uIESzroqpaTzt9uX48HO+6gfnKu3RwvWdCcWSrX4csMInJfCo1yvKPNXCwXFRpJqRW25tiASb6No0YH57PXqg==",
       "dev": true
     },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -2749,8 +2757,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#b37f229a112556bc54d71e0fe812584115c51c28",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v6.7.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#4634d39781b7b70397e21d7b93523131783baf39",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v6.9.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
@@ -2761,16 +2769,6 @@
         "express-validator": "^6.10.0",
         "luxon": "^2.3.0",
         "twilio": "^3.54.2"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        }
       }
     },
     "browser-stdout": {
@@ -4855,7 +4853,7 @@
     "lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "luxon": {
       "version": "2.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aws-sdk/client-iot": "^3.78.0",
     "@aws-sdk/client-iot-wireless": "^3.50.0",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v6.7.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v6.9.0",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.5",
     "express": "^4.16.4",


### PR DESCRIPTION
- This was an annoying bug that's been around for awhile. If the
  most recent session was Completed and the server received a new
  text from the Responder Phone, it would treat it as though it
  were a response to the most recent incompleted session.
- We are about to implement multiple Responder phones, which will
  make it much more likely that a text message will be sent after
  a session is complete, thus making this bug more likely to be
  seen

## Test Plan
- :heavy_check_mark: Deploy to Dev
- :heavy_check_mark: Run through all the normal cases and check status on Dashboard
   - :heavy_check_mark: Respond OK right away, see incident category question
   - :heavy_check_mark: Respond valid incident category, see details question
   - :heavy_check_mark: Respond invalid incident category, see invalid category message
   - :heavy_check_mark: Respond with notes, see thank you message
   - :heavy_check_mark: Respond after the thank you message (do this more than once)
      - :heavy_check_mark: See no active session message
      - :heavy_check_mark: No Sentry log
   - :heavy_check_mark: Do not respond OK right away
      - :heavy_check_mark: See Reminder Message
   - :heavy_check_mark: Respond OK after the Reminder Message
      - :heavy_check_mark: See same flow as if you pushed OK right away
   - :heavy_check_mark: Do not respond OK after the Reminder Message
      - :heavy_check_mark: See Fallback message 
   - :heavy_check_mark: Multiple Button presses
      - :heavy_check_mark: See Urgent message