### PR TITLE
Add Country, Country Subdivision, and Building Type to CSV Export (CU-2c6crcn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ the code was deployed.
 
 - Buttons Vitals cache table of only the most recent heartbeat from each Button (CU-2dm6xaf).
 - Gateway Vitals cache table of only the most recent seen timestamp from each Gateway (CU-2dm6xaf).
+- Country, Country Subdivision, and Building Type columns to the CSV Export (CU-2c6crcn).
 
 ### Removed
 

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -284,6 +284,9 @@ async function downloadCsv(req, res) {
     'Button Serial Number',
     'Session Responded At',
     'Session Responded By',
+    'Country',
+    'Country Subdivision',
+    'Building Type',
   ]
 
   const csvParser = new Parser({ fields })

--- a/server/db/034-addclientsextensiontable.sql
+++ b/server/db/034-addclientsextensiontable.sql
@@ -1,0 +1,58 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 34;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        -- Add new client extension table
+        CREATE TABLE IF NOT EXISTS clients_extension (
+            client_id uuid PRIMARY KEY REFERENCES clients (id),
+            country text,
+            country_subdivision text,
+            building_type text,
+            created_at timestamptz NOT NULL default now(),
+            updated_at timestamptz NOT NULL default now()
+        );
+
+        -- Add a trigger to update the clients_extension.updated_at column
+        CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+        RETURNS TRIGGER AS $t$
+        BEGIN
+            NEW.updated_at = NOW();
+            RETURN NEW;
+        END;
+        $t$ LANGUAGE plpgsql;
+
+        CREATE TRIGGER set_clients_extension_timestamp
+        BEFORE UPDATE ON clients_extension
+        FOR EACH ROW EXECUTE PROCEDURE trigger_set_timestamp();
+
+        -- Add a trigger to add a row to clients_exension whenever a new row is added to clients
+        CREATE OR REPLACE FUNCTION insert_clients_extension_trigger_fn()
+        RETURNS TRIGGER LANGUAGE PLPGSQL AS $t$
+        BEGIN
+            INSERT INTO clients_extension (client_id) 
+            VALUES (NEW.id)
+            ON CONFLICT (client_id)
+            DO NOTHING;
+            RETURN NEW;
+        END;
+        $t$;
+
+        CREATE TRIGGER add_clients_extension_trigger
+        AFTER INSERT ON clients
+        FOR EACH ROW EXECUTE PROCEDURE insert_clients_extension_trigger_fn();
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -770,6 +770,16 @@ async function clearClients(pgClient) {
 
   try {
     await helpers.runQuery(
+      'clearClientsExtension',
+      `
+      DELETE FROM clients_extension
+      `,
+      [],
+      pool,
+      pgClient,
+    )
+
+    await helpers.runQuery(
       'clearClients',
       `
       DELETE FROM clients
@@ -1228,10 +1238,14 @@ async function getDataForExport(pgClient) {
         TO_CHAR(b.updated_at, 'yyyy-MM-dd HH24:mi:ss') AS "Button Last Updated",
         b.button_serial_number AS "Button Serial Number",
         TO_CHAR(s.responded_at, 'yyyy-MM-dd HH24:mi:ss') AS "Session Responded At",
-        s.responded_by_phone_number AS "Session Responded By"
+        s.responded_by_phone_number AS "Session Responded By",
+        x.country AS "Country",
+        x.country_subdivision AS "Country Subdivision",
+        x.building_type AS "Building Type"
       FROM sessions AS s
         LEFT JOIN buttons AS b ON s.button_id = b.id
         LEFT JOIN clients AS c ON c.id = b.client_id
+        LEFT JOIN clients_extension x on x.client_id = c.id
       `,
       [],
       pool,

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -32,3 +32,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USE
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/031-addclientlanguage.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/032-addbuttonsvitalscachetable.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/033-addgatewaysvitalscachetable.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/034-addclientsextensiontable.sql


### PR DESCRIPTION
- Used an extension table because this data is only every used by
  the CSV export and I didn't want to have to alter the Client
  object to add fields that aren't used anywhere else in the
  program. This also gives the flexibility to easily add and remove
  columns in this table for this need as more reporting requirements
  come up or change
- For now, it is an MVP and is not included
  on the New Client or Update Client pages. If it is missing when
  someone does the CSV export and they need it filled in, they
  can ask someone to add it to the DB
- Just used the `text` datatype to keep this super flexible for now.
  If we find that it's a problem later, we can introduce an enum type.
- Every time a new client is added to the DB, automatically create an
  empty row in the clients_extension table for it. This will make it
  more obvious when we are missing data that needs to be filled in
  manually in that table

## Test Plan
- :heavy_check_mark: Deploy to Dev
- :heavy_check_mark: Export CSV
   - :heavy_check_mark: Old columns still have the correct data
   - :heavy_check_mark: Country column exists and has the correct values
   - :heavy_check_mark: Country Subdivision column exists and has the correct values
   - :heavy_check_mark: Building Type column exists and has the correct values
- :heavy_check_mark: Add country, country subdivision, and/or building type to some and then all of clients to see that it is allowed to be blank and that all the values appear in the exported CSV
- :heavy_check_mark: Create a new Client
   - :heavy_check_mark: Empty row in clients_extension is added
- :heavy_check_mark: Update an existing Client that has an entry in the client_extension table
- :heavy_check_mark: Update an existing Client that does not have an entry in the client_extension table