### PR TITLE
Allow Twilio numbers to be shared across clients (CU-2fk3y8a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the code was deployed.
 ### Changed
 
 - Upgraded to Node 16 and NodePostgres 8 (CU-28na1ge).
+- Allow Twilio numbers to be shared across clients (CU-2fk3y8a).
 
 ### Added
 

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -10,7 +10,7 @@ class BraveAlerterConfigurator {
   createBraveAlerter() {
     return new BraveAlerter(
       this.getAlertSession.bind(this),
-      this.getAlertSessionByPhoneNumber.bind(this),
+      this.getAlertSessionByPhoneNumbers.bind(this),
       this.getAlertSessionBySessionIdAndAlertApiKey.bind(this),
       this.alertSessionChangedCallback,
       this.getLocationByAlertApiKey.bind(this),
@@ -66,18 +66,18 @@ class BraveAlerterConfigurator {
     )
   }
 
-  async getAlertSessionByPhoneNumber(toPhoneNumber) {
+  async getAlertSessionByPhoneNumbers(devicePhoneNumber, responderPhoneNumber) {
     let alertSession = null
 
     try {
-      const session = await db.getMostRecentSessionWithPhoneNumber(toPhoneNumber)
+      const session = await db.getMostRecentSessionWithPhoneNumbers(devicePhoneNumber, responderPhoneNumber)
       if (session === null) {
         return null
       }
 
       alertSession = await this.createAlertSessionFromSession(session)
     } catch (e) {
-      helpers.logError(`getAlertSessionByPhoneNumber: failed to get and create a new alert session: ${e.toString()}`)
+      helpers.logError(`getAlertSessionByPhoneNumbers: failed to get and create a new alert session: ${e.toString()}`)
     }
 
     return alertSession

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -252,19 +252,21 @@ async function getUnrespondedSessionWithButtonId(buttonId, pgClient) {
   return null
 }
 
-async function getMostRecentSessionWithPhoneNumber(phoneNumber, pgClient) {
+async function getMostRecentSessionWithPhoneNumbers(devicePhoneNumber, responderPhoneNumber, pgClient) {
   try {
     const results = await helpers.runQuery(
-      'getMostRecentSessionWithPhoneNumber',
+      'getMostRecentSessionWithPhoneNumbers',
       `
       SELECT s.*
       FROM sessions AS s
       LEFT JOIN buttons AS b ON s.button_id = b.id
+      LEFT JOIN clients AS c ON b.client_id = c.id
       WHERE b.phone_number = $1
+      AND $2 = ANY(c.responder_phone_numbers)
       ORDER BY created_at DESC
       LIMIT 1
       `,
-      [phoneNumber],
+      [devicePhoneNumber, responderPhoneNumber],
       pool,
       pgClient,
     )
@@ -1367,7 +1369,7 @@ module.exports = {
   getClientWithId,
   getClientWithSessionId,
   getGateways,
-  getMostRecentSessionWithPhoneNumber,
+  getMostRecentSessionWithPhoneNumbers,
   getNewNotificationsCountByAlertApiKey,
   getPool,
   getRecentButtonsVitals,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-iot": "^3.78.0",
         "@aws-sdk/client-iot-wireless": "^3.50.0",
-        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v8.1.0",
+        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v9.0.0",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "express": "^4.17.1",
@@ -2300,8 +2300,8 @@
       }
     },
     "node_modules/brave-alert-lib": {
-      "version": "8.1.0",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#77064ead6dd022f8aa32daa1a9d5e2ca0aa17220",
+      "version": "9.0.0",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#45c691e78306336a85b2e688be1d50e22d585ecc",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
@@ -9458,8 +9458,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#77064ead6dd022f8aa32daa1a9d5e2ca0aa17220",
-      "from": "brave-alert-lib@https://github.com/bravetechnologycoop/brave-alert-lib#v8.1.0",
+      "version": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#45c691e78306336a85b2e688be1d50e22d585ecc",
+      "from": "brave-alert-lib@https://github.com/bravetechnologycoop/brave-alert-lib#v9.0.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aws-sdk/client-iot": "^3.78.0",
     "@aws-sdk/client-iot-wireless": "^3.50.0",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v8.1.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v9.0.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumbersTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumbersTest.js
@@ -8,12 +8,12 @@ const db = require('../../../db/db')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
 const { sessionDBFactory, buttonDBFactory } = require('../../testingHelpers')
 
-describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneNumber', () => {
+describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneNumbers', () => {
   beforeEach(async () => {
     this.chatbotState = CHATBOT_STATE.WAITING_FOR_CATEGORY
     this.sessionIncidentCategory = '2'
     this.sessionToPhoneNumber = '+13335557777'
-    this.installationResponderPhoneNumbers = ['+17775558888']
+    this.installationResponderPhoneNumbers = ['+17775558888', '+18885554444']
     this.installationIncidentCategories = ['Cat1', 'Cat2', 'Cat3']
     this.language = 'de'
     this.respondedByPhoneNumber = '+11114442222'
@@ -48,10 +48,10 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
     await db.clearTables()
   })
 
-  it('should return an AlertSession with the values from the DB', async () => {
+  it('when given a matching set of phone numbers, should return an AlertSession with the values from the DB', async () => {
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-    const alertSession = await braveAlerter.getAlertSessionByPhoneNumber(this.sessionToPhoneNumber)
+    const alertSession = await braveAlerter.getAlertSessionByPhoneNumbers(this.sessionToPhoneNumber, this.installationResponderPhoneNumbers[1])
 
     expect(alertSession).to.eql(
       new AlertSession(
@@ -65,5 +65,21 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
         this.language,
       ),
     )
+  })
+
+  it('when given a matching devicePhoneNumber but mismatched responderPhoneNumber, should return null', async () => {
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    const alertSession = await braveAlerter.getAlertSessionByPhoneNumbers(this.sessionToPhoneNumber, 'not one of the responderPhoneNumbers')
+
+    expect(alertSession).to.be.null
+  })
+
+  it('when given a matching responderPhoneNumber but mismatched devicePhoneNumber, should return null', async () => {
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    const alertSession = await braveAlerter.getAlertSessionByPhoneNumbers('not the device phone number', this.installationResponderPhoneNumbers[0])
+
+    expect(alertSession).to.be.null
   })
 })


### PR DESCRIPTION
- When an SMS arrives from a phone, use both the fromNumber and the
  toNumber to determine the most recent session instead of just the
  toNumber. The toNumber should match one of the Buttons' phone number
  and the fromNumber should match one of the clients'
  responderPhoneNumbers. If there is one that works for both, then it's
  the right session, if not, then it didn't find any
- Note that an SMS can come from any of the client's
  responderPhoneNumbers, not just the one that initially responded to
  the session

## Test Plan
- :heavy_check_mark: Deploy to Dev
- Set up two clients as follows:
   - Client 1:
      - ResponderPhoneNumber: My phone number
      - Button A:
         - TwilioPhoneNumber: Valid dev Twilio number
   - Client 2:
      - ResponderPhoneNumber: James' phone number
      - Button B:
         - TwilioPhoneNumber: SAME valid dev Twilio number

   and run tests:
   - :heavy_check_mark: Create a new session for Button A but none for Button B and reply from my phone number, should advance the chatbot for Button A
   - :heavy_check_mark: Create a new session for Button A but none for Button B and reply from James' phone number, should say "Thank you" because there is no active session
   - :heavy_check_mark: Create a new session for Button A then for Button B and reply from my phone, should advance the chatbot for Button A, reply from my phone again, should advance the chatbot for Button A
   - :heavy_check_mark: Create a new session for Button A then for Button B and reply from my phone, should advance the chatbot for Button A, reply from James' phone, should advance the chatbot for Button B, reply from my phone again, should advance the chatbot for Button A
   - :heavy_check_mark: Create a new session for Button A then for Button B and reply from James' phone, should advance the chatbot for Button B, reply from James' phone again, should advance the chatbot for Button B
   - :heavy_check_mark: Create a new session for Button A then for Button B and reply from James' phone, should advance the chatbot for Button B, reply from my phone, should advance the chatbot for Button A, reply from my phone again, should advance the chatbot for Button A, reply from James' phone again, should advance the chatbot for Button B
- :heavy_check_mark: Make sure multiple responder phones still works
- :heavy_check_mark: Dashboard
   - :heavy_check_mark: Most recent sessions on Client page