### PR TITLE
Send disconnection messages to Sentry for RAK Buttons (CU-208arfp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ the code was deployed.
 
 - Disconnection/reconnection SMS messages to Heartbeat Phone Numbers for RAK Gateways (CU-208arfp).
 - Low battery SMS messages to Heartbeat Phone Numbers for RAK Buttons (CU-208arfp).
+- Disconnection/reconnection Sentry messages for RAK Buttons (CU-208arfp).`
 
 ## [10.1.0] - 2022-07-25
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -99,6 +99,10 @@ VITALS_ALERT_THRESHOLD_TEST=900
 GATEWAY_VITALS_ALERT_THRESHOLD=2160
 GATEWAY_VITALS_ALERT_THRESHOLD_TEST=900
 
+# Threshold for sending out an initial RAK Button Disconnection message to Sentry (in seconds)
+RAK_BUTTONS_VITALS_ALERT_THRESHOLD=8100
+RAK_BUTTONS_VITALS_ALERT_THRESHOLD_TEST=8100
+
 # Theshold for sending out an initial Button Low Battery message to the Heatbeat Recipients (in percentage)
 BUTTON_LOW_BATTERY_ALERT_THRESHOLD=20
 BUTTON_LOW_BATTERY_ALERT_THRESHOLD_TEST=20

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1282,6 +1282,26 @@ async function updateButtonsSentLowBatteryAlerts(buttonId, sentalerts, pgClient)
   }
 }
 
+async function updateButtonsSentVitalsAlerts(buttonId, sentalerts, pgClient) {
+  try {
+    const query = sentalerts
+      ? `
+        UPDATE buttons
+        SET sent_vitals_alert_at = NOW()
+        WHERE id = $1
+      `
+      : `
+        UPDATE buttons
+        SET sent_vitals_alert_at = NULL
+        WHERE id = $1
+      `
+
+    await helpers.runQuery('updateButtonSentVitalsAlerts', query, [buttonId], pool, pgClient)
+  } catch (err) {
+    helpers.logError(err.toString())
+  }
+}
+
 async function getDataForExport(pgClient) {
   try {
     const results = await helpers.runQuery(
@@ -1455,6 +1475,7 @@ module.exports = {
   saveHeartbeat,
   saveSession,
   updateButtonsSentLowBatteryAlerts,
+  updateButtonsSentVitalsAlerts,
   updateGatewaySentVitalsAlerts,
   updateHubSentVitalsAlerts,
   updateSentInternalAlerts,

--- a/server/server.js
+++ b/server/server.js
@@ -51,6 +51,7 @@ if (helpers.isTestEnvironment()) {
   setInterval(vitals.checkHubHeartbeat, 10 * 1000)
   setInterval(vitals.checkGatewayHeartbeat, 5 * 60 * 1000)
   setInterval(vitals.checkButtonBatteries, 5 * 60 * 1000)
+  setInterval(vitals.checkButtonHeartbeat, 5 * 60 * 1000)
   helpers.log('brave server listening on port 443')
 }
 

--- a/server/test/unit/vitalsTest/checkButtonBatteriesTest.js
+++ b/server/test/unit/vitalsTest/checkButtonBatteriesTest.js
@@ -105,7 +105,7 @@ describe('vitals.js unit tests: checkButtonBatteries', () => {
       )
     })
 
-    it("should update the gateway's sentVitalsAlertAt the database to null", async () => {
+    it("should update the button's sentLowBatteryAlertAt the database to null", async () => {
       await vitals.checkButtonBatteries()
       expect(db.updateButtonsSentLowBatteryAlerts).to.be.calledWithExactly(this.button.id, false)
     })

--- a/server/test/unit/vitalsTest/checkButtonHeartbeatTest.js
+++ b/server/test/unit/vitalsTest/checkButtonHeartbeatTest.js
@@ -1,0 +1,247 @@
+// Third-party dependencies
+const { expect, use } = require('chai')
+const { describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const { DateTime } = require('luxon')
+
+// In-house dependencies
+const { helpers, factories } = require('brave-alert-lib')
+const db = require('../../../db/db')
+const { buttonFactory, buttonsVitalFactory } = require('../../testingHelpers')
+const vitals = require('../../../vitals')
+
+use(sinonChai)
+
+const sandbox = sinon.createSandbox()
+
+const currentDBDate = new Date('2021-11-04T22:28:28.0248Z')
+
+const heartbeatThreshold = 3600
+
+// Expects JS Date objects
+function subtractSeconds(date, seconds) {
+  const dateTime = DateTime.fromJSDate(date)
+  return dateTime.minus({ seconds }).toJSDate()
+}
+
+const exceededThresholdTimestamp = subtractSeconds(currentDBDate, heartbeatThreshold + 1) // sub(currentDBDate, { seconds: subsequentVitalsThreshold + 1 })
+
+describe('vitals.js unit tests: checkButtonHeartbeat', () => {
+  /* eslint-disable no-underscore-dangle */
+  beforeEach(() => {
+    const getEnvVarStub = sandbox.stub(helpers, 'getEnvVar')
+    getEnvVarStub.withArgs('RAK_BUTTONS_VITALS_ALERT_THRESHOLD').returns(heartbeatThreshold)
+
+    sandbox.stub(db, 'getCurrentTime').returns(currentDBDate)
+    sandbox.stub(db, 'updateButtonsSentVitalsAlerts')
+
+    sandbox.stub(helpers, 'logSentry')
+    sandbox.spy(helpers, 'logError')
+    sandbox.spy(helpers, 'log')
+
+    this.sendNotificationStub = sandbox.stub()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('when active button last seen is more recent than the threshold and no alerts have been sent ', () => {
+    beforeEach(async () => {
+      this.button = buttonFactory({ sentVitalsAlertAt: null, isActive: true, client: factories.clientFactory({ isActive: true }) })
+      sandbox.stub(db, 'getButtons').returns([this.button])
+      this.buttonsVital = buttonsVitalFactory({
+        createdAt: currentDBDate,
+        button: this.button,
+      })
+      sandbox.stub(db, 'getRecentButtonsVitals').returns([this.buttonsVital])
+    })
+
+    it('should not send a disconnection message to Sentry', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(helpers.logSentry).to.not.be.called
+    })
+
+    it('should not update the database', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(db.updateButtonsSentVitalsAlerts).to.not.be.called
+    })
+  })
+
+  describe('when active button last seen exceeds the threshold and no alerts have been sent', () => {
+    beforeEach(async () => {
+      this.button = buttonFactory({ sentVitalsAlertAt: null, isActive: true, client: factories.clientFactory({ isActive: true }) })
+      sandbox.stub(db, 'getButtons').returns([this.button])
+      this.buttonsVital = buttonsVitalFactory({
+        createdAt: exceededThresholdTimestamp,
+        button: this.button,
+      })
+      sandbox.stub(db, 'getRecentButtonsVitals').returns([this.buttonsVital])
+    })
+
+    it('should send the disconnection message to Sentry', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(helpers.logSentry).to.be.called
+    })
+
+    it('should update the buttons sentVitalsAlertAt in the database to now', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(db.updateButtonsSentVitalsAlerts).to.be.calledWithExactly(this.button.id, true)
+    })
+  })
+
+  describe('when inactive button last seen exceeds the threshold and no alerts have been sent', () => {
+    beforeEach(async () => {
+      this.button = buttonFactory({ sentVitalsAlertAt: null, isActive: false, client: factories.clientFactory({ isActive: true }) })
+      sandbox.stub(db, 'getButtons').returns([this.button])
+      this.buttonsVital = buttonsVitalFactory({
+        createdAt: exceededThresholdTimestamp,
+        button: this.button,
+      })
+      sandbox.stub(db, 'getRecentButtonsVitals').returns([this.buttonsVital])
+    })
+
+    it('should not send a disconnection message to Sentry', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(helpers.logSentry).to.not.be.called
+    })
+
+    it('should not update the database', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(db.updateButtonsSentVitalsAlerts).to.not.be.called
+    })
+  })
+
+  describe("when inactive client's active button last seen exceeds the threshold and no alerts have been sent", () => {
+    beforeEach(async () => {
+      this.button = buttonFactory({ sentVitalsAlertAt: null, isActive: true, client: factories.clientFactory({ isActive: false }) })
+      sandbox.stub(db, 'getButtons').returns([this.button])
+      this.buttonsVital = buttonsVitalFactory({
+        createdAt: exceededThresholdTimestamp,
+        button: this.button,
+      })
+      sandbox.stub(db, 'getRecentButtonsVitals').returns([this.buttonsVital])
+    })
+
+    it('should not send a disconnection message to Sentry', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(helpers.logSentry).to.not.be.called
+    })
+
+    it('should not update the database', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(db.updateButtonsSentVitalsAlerts).to.not.be.called
+    })
+  })
+
+  describe("when inactive client's inactive button last seen exceeds the threshold and no alerts have been sent", () => {
+    beforeEach(async () => {
+      this.button = buttonFactory({ sentVitalsAlertAt: null, isActive: false, client: factories.clientFactory({ isActive: false }) })
+      sandbox.stub(db, 'getButtons').returns([this.button])
+      this.buttonsVital = buttonsVitalFactory({
+        createdAt: exceededThresholdTimestamp,
+        button: this.button,
+      })
+      sandbox.stub(db, 'getRecentButtonsVitals').returns([this.buttonsVital])
+    })
+
+    it('should not send a disconnection message to Sentry', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(helpers.logSentry).to.not.be.called
+    })
+
+    it('should not update the database', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(db.updateButtonsSentVitalsAlerts).to.not.be.called
+    })
+  })
+
+  describe('when active button last seen is more recent than the threshold and an alert was sent ', () => {
+    beforeEach(async () => {
+      this.button = buttonFactory({ sentVitalsAlertAt: new Date(), isActive: true, client: factories.clientFactory({ isActive: true }) })
+      sandbox.stub(db, 'getButtons').returns([this.button])
+      this.buttonsVital = buttonsVitalFactory({
+        createdAt: currentDBDate,
+        button: this.button,
+      })
+      sandbox.stub(db, 'getRecentButtonsVitals').returns([this.buttonsVital])
+    })
+
+    it('should send the reconnection message to Sentry', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(helpers.logSentry).to.be.called
+    })
+
+    it("should update the button's sentVitalsAlertAt the database to null", async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(db.updateButtonsSentVitalsAlerts).to.be.calledWithExactly(this.button.id, false)
+    })
+  })
+
+  describe('when inactive button last seen is more recent than the threshold and an alert was sent ', () => {
+    beforeEach(async () => {
+      this.button = buttonFactory({ sentVitalsAlertAt: new Date(), isActive: false, client: factories.clientFactory({ isActive: true }) })
+      sandbox.stub(db, 'getButtons').returns([this.button])
+      this.buttonsVital = buttonsVitalFactory({
+        createdAt: currentDBDate,
+        button: this.button,
+      })
+      sandbox.stub(db, 'getRecentButtonsVitals').returns([this.buttonsVital])
+    })
+
+    it('should not send a disconnection message to Sentry', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(helpers.logSentry).to.not.be.called
+    })
+
+    it('should not update the database', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(db.updateButtonsSentVitalsAlerts).to.not.be.called
+    })
+  })
+
+  describe("when inactive client's active button last seen is more recent than the threshold and an alert was sent ", () => {
+    beforeEach(async () => {
+      this.button = buttonFactory({ sentVitalsAlertAt: new Date(), isActive: true, client: factories.clientFactory({ isActive: false }) })
+      sandbox.stub(db, 'getButtons').returns([this.button])
+      this.buttonsVital = buttonsVitalFactory({
+        createdAt: currentDBDate,
+        button: this.button,
+      })
+      sandbox.stub(db, 'getRecentButtonsVitals').returns([this.buttonsVital])
+    })
+
+    it('should not send a disconnection message to Sentry', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(helpers.logSentry).to.not.be.called
+    })
+
+    it('should not update the database', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(db.updateButtonsSentVitalsAlerts).to.not.be.called
+    })
+  })
+
+  describe("when inactive client's inactive button last seen is more recent than the threshold and an alert was sent ", () => {
+    beforeEach(async () => {
+      this.button = buttonFactory({ sentVitalsAlertAt: new Date(), isActive: false, client: factories.clientFactory({ isActive: false }) })
+      sandbox.stub(db, 'getButtons').returns([this.button])
+      this.buttonsVital = buttonsVitalFactory({
+        createdAt: currentDBDate,
+        button: this.button,
+      })
+      sandbox.stub(db, 'getRecentButtonsVitals').returns([this.buttonsVital])
+    })
+
+    it('should not send a disconnection message to Sentry', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(helpers.logSentry).to.not.be.called
+    })
+
+    it('should not update the database', async () => {
+      await vitals.checkButtonHeartbeat()
+      expect(db.updateButtonsSentVitalsAlerts).to.not.be.called
+    })
+  })
+})


### PR DESCRIPTION
- For now, only sends to Sentry so that we can restrict
  it to just us Brave people until we know for sure that these messages
  are reliable and not too noisy

## Test Plan
- :heavy_check_mark: Run through normal chatbot
- :heavy_check_mark: Set my client and my Button to active
   -  :heavy_check_mark: Sentry receives the Button disconnect message when buttonVitals.createdAt is older than the threshold
   - :heavy_check_mark: Sentry receives the Button reconnection message when buttonVitals.createdAt is more recent than the threshold
- :heavy_check_mark: Set my client to active but Button to inactive
   - :heavy_check_mark: Do not receive any Sentry messages
- :heavy_check_mark: Set my client and Button to inactive
   - :heavy_check_mark: Do not receive any Sentry messages
- :heavy_check_mark: Set my client to inactive but Button to active
   - :heavy_check_mark: Do not receive any Sentry messages