### PR TITLE
Pressing RAK Button 4 starts an alert (CU-2uadjfh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- RAK Button 4 can be used to trigger alerts (CU-2uadjfh).
+
 ## [10.2.0] - 2022-08-22
 
 ### Changed

--- a/server/rak.js
+++ b/server/rak.js
@@ -41,7 +41,7 @@ async function handleButtonPress(req, res) {
 
       if (event[0] === EVENT_TYPE.HEARTBEAT && button !== null) {
         await db.logButtonsVital(button.id, event[1])
-      } else if (event[0] === EVENT_TYPE.BUTTON_PRESS_3) {
+      } else if (event[0] === EVENT_TYPE.BUTTON_PRESS_4 || event[0] === EVENT_TYPE.BUTTON_PRESS_3) {
         if (button === null) {
           const errorMessage = `Bad request to ${req.path}: DevEui is not registered: '${devEui}'`
           helpers.logError(errorMessage)

--- a/server/test/integration/rakTest/handleButtonPressTest.js
+++ b/server/test/integration/rakTest/handleButtonPressTest.js
@@ -257,8 +257,8 @@ describe('rak.js integration tests: handleButtonpress', () => {
       expect(helpers.logError).not.to.be.called
     })
 
-    it('should not handle the button press', () => {
-      expect(buttonAlerts.handleValidRequest).not.to.be.called
+    it('should handle the button press', () => {
+      expect(buttonAlerts.handleValidRequest).to.be.calledWithExactly(this.button, 1)
     })
   })
 


### PR DESCRIPTION
- The new injection-moulded Buttons will push on Button 4 instead of Button 3. We still have 3D-printed Buttons in production, so did not remove the alerting ability of Button 3, which it uses.

## Test plan
- ✔️ Deploy to Dev
- ✔️ Push Button 4 once and multiple times, should start an alert and also send expected urgent alerts
- ✔️ Push Button 3 once and multiple times, should start an alert and also send expected urgent alerts
- ✔️ Push Button 1 once and multiple times, should NOT start any alerts
- ✔️ Push Button 2 once and multiple times, should NOT start any alerts
- ✔️ Push a combination of Buttons 3 and 4, should start an alert and also send expected urgent alerts