### PR TITLE
Add US Spanish translations for chatbot (CU-38tu7z8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Spanish messages (CU-38tu7z8).
+
 ## [10.3.0] - 2022-11-01
 
 ### Added

--- a/server/i18nextHelpers.js
+++ b/server/i18nextHelpers.js
@@ -5,6 +5,7 @@ const i18next = require('i18next')
 const { helpers } = require('brave-alert-lib')
 const CommonEn = require('./resources/translations/common.en.json')
 const CommonEnFrBilingual = require('./resources/translations/common.en_fr_bilingual.json')
+const CommonEsUs = require('./resources/translations/common.es_us.json')
 
 const namespaces = ['chatbot']
 const resources = {
@@ -14,6 +15,9 @@ const resources = {
   en_fr_bilingual: {
     common: CommonEnFrBilingual,
   },
+  es_us: {
+    common: CommonEsUs,
+  },
 }
 
 function setup() {
@@ -22,7 +26,7 @@ function setup() {
       resources,
       debug: false,
       fallbackLng: 'en',
-      supportedLngs: ['en', 'en_fr_bilingual'],
+      supportedLngs: ['en', 'en_fr_bilingual', 'es_us'],
       ns: namespaces,
       defaultNS: 'common',
       interpolation: {

--- a/server/resources/translations/common.es_us.json
+++ b/server/resources/translations/common.es_us.json
@@ -1,0 +1,22 @@
+{
+  "alertAcknowledged": "Otro personal de auxilio ha confirmado esta solicitud. (No necesita responder a este mensaje).",
+  "alertCompleted": "Gracias. Esta sesión ya está completa. (No necesita responder a este mensaje).",
+  "alertFallback": "Ha habido una solicitud sin respuesta en {{ clientDisplayName }} {{ buttonDisplayName }}",
+  "alertReminder": "Responda \"Ok\" si le ha dado seguimiento a su llamada. Si no responde dentro 2 minutos, se emitirá una alerta de emergencia al personal.",
+  "alertStart": "Ha habido una solicitud de ayuda de {{ buttonDisplayName }}. Responda \"Ok\" cuando le haya dado seguimiento a la llamada.",
+  "alertUrgent": "Es una solicitud urgente. El Button se ha presionado {{ numButtonPresses }} veces. Responda \"Ok\" cuando le haya dado seguimiento a la llamada.",
+  "buttonLowBatteryInitial": "La batería del Button {{ buttonDisplayName }} está baja y necesita recargarse. Para ver un video que muestra cómo recargar la batería, vaya a https://www.youtube.com/watch?v=h7_5ff-_r5A",
+  "buttonLowBatteryReminder": "La batería del Button {{ buttonDisplayName }} sigue baja y necesita recargarse.\n\nPara ver un video que muestra cómo recargar la batería, vaya a https://www.youtube.com/watch?v=h7_5ff-_r5A",
+  "buttonLowBatteryNoLonger": "La batería del Button {{ buttonDisplayName }} ya no está baja. Gracias.",
+  "errorNoSession": "Error: No se encontró ninguna sesión activa",
+  "gatewayDisconnectionInitial": "Se perdió la conexión de la Central de Buttons {{ gatewayDisplayName }}.\nDesenchufe la central y vuelva a enchufarla para restablecerla. Si no recibe un mensaje de reconexión poco después de hacer esto, envíe un correo electrónico a clientsupport@brave.coop.",
+  "gatewayDisconnectionReminder": "La Central de Buttons {{ gatewayDisplayName }} sigue desconectada.\nDesenchufe la central y vuelva a enchufarla para restablecerla. Si no recibe un mensaje de reconexión poco después de hacer esto, envíe un correo electrónico a clientsupport@brave.coop.",
+  "gatewayReconnection": "La Central de Buttons {{ gatewayDisplayName }} se ha reconectado.",
+  "hubDisconnectionInitial": "Se ha perdido la conexión para la Central de Buttons {{ hubLocationDescription }}.\nDesenchufe la central y vuelva a enchufarla para restablecerla. Si no recibe un mensaje de reconexión pocco después de hacer esto, comuníquese con su administrador de red.\nTambién puede enviar un correo electrónico a clientsupport@brave.coop para obtener ayuda adicional.",
+  "hubDisconnectionReminder": "La Central de Buttons {{ hubLocationDescription }} sigue desconectada.\nDesenchufe la central y vuelva a enchufarla para restablecerla. Si no recibe un mensaje de reconexión pocco después de hacer esto, comuníquese con su administrador de red.\nTambién puede enviar un correo electrónico a clientsupport@brave.coop para obtener ayuda adicional.",
+  "hubReconnection": "La Central de Buttons {{ hubLocationDescription }} se ha reconectado.",
+  "incidentCategorized": "El incidente se clasificó como {{ incidentCategory }}.\n\nGracias. Esta sesión ya está completa. (No necesita responder a este mensaje).",
+  "incidentCategoryInvalid": "Lo sentimos, no se reconoció el tipo de incidente. Por favor, intente de nuevo.",
+  "incidentCategoryRequest": "Una vez que haya contestado, responda con el número que mejor describa el incidente:\n{{ incidentCategories }}",
+  "thankYou": "Gracias"
+}

--- a/server/test/unit/BraveAlerterConfiguratorTest/getReturnMessageToRespondedByPhoneNumberTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/getReturnMessageToRespondedByPhoneNumberTest.js
@@ -98,4 +98,15 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessageToRespondedByP
       "Maintenant que vous avez répondu, merci de répondre avec le numéro qui décrit le mieux l'incident:\n---\nOnce you have responded, please reply with the number that best describes the incident:\n\n0 - Cat0\n1 - Cat1\n",
     )
   })
+
+  it('should get es_us message', () => {
+    const returnMessage = this.alertStateMachine.getReturnMessageToRespondedByPhoneNumber(
+      'es_us',
+      CHATBOT_STATE.STARTED,
+      CHATBOT_STATE.WAITING_FOR_REPLY,
+      ['Cat0', 'Cat1'],
+    )
+
+    expect(returnMessage).to.equal('Una vez que haya contestado, responda con el número que mejor describa el incidente:\n0 - Cat0\n1 - Cat1\n')
+  })
 })


### PR DESCRIPTION
## Test Plan
- :heavy_check_mark: Deploy to dev
- :heavy_check_mark: Set my physical RAK Button system up to use Spanish
- :heavy_check_mark: Go through the chatbot and see that each one of the strings is sent to me as expected with the right values filled in:
    - :heavy_check_mark:  "alertAcknowledged": "Otro personal de auxilio ha confirmado esta solicitud. (No necesita responder a este mensaje).",
    - :heavy_check_mark: "alertCompleted": "Gracias. Esta sesión ya está completa. (No necesita responder a este mensaje).",
    - :heavy_check_mark: "alertFallback": "Ha habido una solicitud sin respuesta en {{ clientDisplayName }} {{ buttonDisplayName }}",
    - :heavy_check_mark: "alertReminder": "Responda \"Ok\" si le ha dado seguimiento a su llamada. Si no responde dentro 2 minutos, se emitirá una alerta de emergencia al personal.",
    - :heavy_check_mark: "alertStart": "Ha habido una solicitud de ayuda de {{ buttonDisplayName }}. Responda \"Ok\" cuando le haya dado seguimiento a la llamada.",
    - :heavy_check_mark: "alertUrgent": "Es una solicitud urgente. El Button se ha presionado {{ numButtonPresses }} veces. Responda \"Ok\" cuando le haya dado seguimiento a la llamada.",
    - :heavy_check_mark: "buttonLowBatteryInitial": "La batería del Button {{ buttonDisplayName }} está baja y necesita recargarse. Para ver un video que muestra cómo recargar la batería, vaya a https://www.youtube.com/watch?v=h7_5ff-_r5A",
    - :heavy_check_mark: "buttonLowBatteryReminder": "La batería del Button {{ buttonDisplayName }} sigue baja y necesita recargarse.\n\nPara ver un video que muestra cómo recargar la batería, vaya a https://www.youtube.com/watch?v=h7_5ff-_r5A",
    - :heavy_check_mark: "buttonLowBatteryNoLonger": "La batería del Button {{ buttonDisplayName }} ya no está baja. Gracias.",
    - :question: [pretty sure this one isn't actually used anywhere anymore] "errorNoSession": "Error: No se encontró ninguna sesión activa",
    - :heavy_check_mark: "gatewayDisconnectionInitial": "Se perdió la conexión de la Central de Buttons {{ gatewayDisplayName }}.\nDesenchufe la central y vuelva a enchufarla para restablecerla. Si no recibe un mensaje de reconexión poco después de hacer esto, envíe un correo electrónico a clientsupport@brave.coop.",
    - :heavy_check_mark: "gatewayDisconnectionReminder": "La Central de Buttons {{ gatewayDisplayName }} sigue desconectada.\nDesenchufe la central y vuelva a enchufarla para restablecerla. Si no recibe un mensaje de reconexión poco después de hacer esto, envíe un correo electrónico a clientsupport@brave.coop.",
    - :heavy_check_mark: "gatewayReconnection": "La Central de Buttons {{ gatewayDisplayName }} se ha reconectado.",
    - :heavy_check_mark: "hubDisconnectionInitial": "Se ha perdido la conexión para la Central de Buttons {{ hubLocationDescription }}.\nDesenchufe la central y vuelva a enchufarla para restablecerla. Si no recibe un mensaje de reconexión pocco después de hacer esto, comuníquese con su administrador de red.\nTambién puede enviar un correo electrónico a clientsupport@brave.coop para obtener ayuda adicional.",
    - :heavy_check_mark: "hubDisconnectionReminder": "La Central de Buttons {{ hubLocationDescription }} sigue desconectada.\nDesenchufe la central y vuelva a enchufarla para restablecerla. Si no recibe un mensaje de reconexión pocco después de hacer esto, comuníquese con su administrador de red.\nTambién puede enviar un correo electrónico a clientsupport@brave.coop para obtener ayuda adicional.",
    - :heavy_check_mark: "hubReconnection": "La Central de Buttons {{ hubLocationDescription }} se ha reconectado.",
    - :heavy_check_mark: "incidentCategorized": "El incidente se clasificó como {{ incidentCategory }}.\n\nGracias. Esta sesión ya está completa. (No necesita responder a este mensaje).",
    - :heavy_check_mark: "incidentCategoryInvalid": "Lo sentimos, no se reconoció el tipo de incidente. Por favor, intente de nuevo.",
    - :heavy_check_mark: "incidentCategoryRequest": "Una vez que haya contestado, responda con el número que mejor describa el incidente:\n{{ incidentCategories }}",
    - :heavy_check_mark: "thankYou": "Gracias"