### PR TITLE
Send Gateway vitals and RAK low battery alerts to Responder Phones (CU-3bft2mp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the code was deployed.
 ### Added
 
 - Spanish messages (CU-38tu7z8).
+- Responder Phones as receipients of RAK Gateway disconnection, RAK Gateway reconnection, and RAK Button low battery messages (CU-3bft2mp).
 
 ## [10.3.0] - 2022-11-01
 

--- a/server/test/unit/vitalsTest/checkButtonBatteriesTest.js
+++ b/server/test/unit/vitalsTest/checkButtonBatteriesTest.js
@@ -100,7 +100,7 @@ describe('vitals.js unit tests: checkButtonBatteries', () => {
       await vitals.checkButtonBatteries()
       expect(this.sendNotificationStub).to.be.calledWithExactly(
         'buttonLowBatteryNoLonger',
-        this.button.client.heartbeatPhoneNumbers,
+        this.button.client.responderPhoneNumbers.concat(this.button.client.heartbeatPhoneNumbers),
         this.button.client.fromPhoneNumber,
       )
     })
@@ -158,7 +158,7 @@ describe('vitals.js unit tests: checkButtonBatteries', () => {
       await vitals.checkButtonBatteries()
       expect(this.sendNotificationStub).to.be.calledWithExactly(
         'buttonLowBatteryInitial',
-        this.button.client.heartbeatPhoneNumbers,
+        this.button.client.responderPhoneNumbers.concat(this.button.client.heartbeatPhoneNumbers),
         this.button.client.fromPhoneNumber,
       )
     })
@@ -216,7 +216,7 @@ describe('vitals.js unit tests: checkButtonBatteries', () => {
       await vitals.checkButtonBatteries()
       expect(this.sendNotificationStub).to.be.calledWithExactly(
         'buttonLowBatteryReminder',
-        this.button.client.heartbeatPhoneNumbers,
+        this.button.client.responderPhoneNumbers.concat(this.button.client.heartbeatPhoneNumbers),
         this.button.client.fromPhoneNumber,
       )
     })

--- a/server/test/unit/vitalsTest/checkGatewayHeartbeatTest.js
+++ b/server/test/unit/vitalsTest/checkGatewayHeartbeatTest.js
@@ -104,7 +104,7 @@ describe('vitals.js unit tests: checkGatewayHeartbeat', () => {
       await vitals.checkGatewayHeartbeat()
       expect(this.sendNotificationStub).to.be.calledWithExactly(
         'gatewayReconnection',
-        this.gateway.client.heartbeatPhoneNumbers,
+        this.gateway.client.responderPhoneNumbers.concat(this.gateway.client.heartbeatPhoneNumbers),
         this.gateway.client.fromPhoneNumber,
       )
     })
@@ -135,7 +135,7 @@ describe('vitals.js unit tests: checkGatewayHeartbeat', () => {
       await vitals.checkGatewayHeartbeat()
       expect(this.sendNotificationStub).to.be.calledWithExactly(
         'gatewayDisconnectionInitial',
-        this.gateway.client.heartbeatPhoneNumbers,
+        this.gateway.client.responderPhoneNumbers.concat(this.gateway.client.heartbeatPhoneNumbers),
         this.gateway.client.fromPhoneNumber,
       )
     })
@@ -193,7 +193,7 @@ describe('vitals.js unit tests: checkGatewayHeartbeat', () => {
       await vitals.checkGatewayHeartbeat()
       expect(this.sendNotificationStub).to.be.calledWithExactly(
         'gatewayDisconnectionReminder',
-        this.gateway.client.heartbeatPhoneNumbers,
+        this.gateway.client.responderPhoneNumbers.concat(this.gateway.client.heartbeatPhoneNumbers),
         this.gateway.client.fromPhoneNumber,
       )
     })

--- a/server/vitals.js
+++ b/server/vitals.js
@@ -144,7 +144,7 @@ async function checkGatewayHeartbeat() {
 
             sendNotification(
               i18next.t('gatewayDisconnectionInitial', { lng: client.language, gatewayDisplayName: gateway.displayName }),
-              client.heartbeatPhoneNumbers, // TODO Also send to the Responder Phones once we know that these messages are reliable
+              client.responderPhoneNumbers.concat(client.heartbeatPhoneNumbers),
               client.fromPhoneNumber,
             )
           } else if (differenceInSeconds(currentTime, gateway.sentVitalsAlertAt) > SUBSEQUENT_THRESHOLD) {
@@ -152,7 +152,7 @@ async function checkGatewayHeartbeat() {
 
             sendNotification(
               i18next.t('gatewayDisconnectionReminder', { lng: client.language, gatewayDisplayName: gateway.displayName }),
-              client.heartbeatPhoneNumbers, // TODO Also send to the Responder Phones once we know that these messages are reliable
+              client.responderPhoneNumbers.concat(client.heartbeatPhoneNumbers),
               client.fromPhoneNumber,
             )
           }
@@ -164,7 +164,7 @@ async function checkGatewayHeartbeat() {
 
           sendNotification(
             i18next.t('gatewayReconnection', { lng: client.language, gatewayDisplayName: gateway.displayName }),
-            client.heartbeatPhoneNumbers, // TODO Also send to the Responder Phones once we know that these messages are reliable
+            client.responderPhoneNumbers.concat(client.heartbeatPhoneNumbers),
             client.fromPhoneNumber,
           )
         }
@@ -197,7 +197,7 @@ async function checkButtonBatteries() {
 
             sendNotification(
               i18next.t('buttonLowBatteryInitial', { lng: client.language, buttonDisplayName: button.displayName }),
-              client.heartbeatPhoneNumbers, // TODO Also send to the Responder Phones once we know that these messages are reliable
+              client.responderPhoneNumbers.concat(client.heartbeatPhoneNumbers),
               client.fromPhoneNumber,
             )
           } else if (differenceInSeconds(currentTime, button.sentLowBatteryAlertAt) > SUBSEQUENT_THRESHOLD) {
@@ -205,7 +205,7 @@ async function checkButtonBatteries() {
 
             sendNotification(
               i18next.t('buttonLowBatteryReminder', { lng: client.language, buttonDisplayName: button.displayName }),
-              client.heartbeatPhoneNumbers, // TODO Also send to the Responder Phones once we know that these messages are reliable
+              client.responderPhoneNumbers.concat(client.heartbeatPhoneNumbers),
               client.fromPhoneNumber,
             )
           }
@@ -217,7 +217,7 @@ async function checkButtonBatteries() {
 
           sendNotification(
             i18next.t('buttonLowBatteryNoLonger', { lng: client.language, buttonDisplayName: button.displayName }),
-            client.heartbeatPhoneNumbers, // TODO Also send to the Responder Phones once we know that these messages are reliable
+            client.responderPhoneNumbers.concat(client.heartbeatPhoneNumbers),
             client.fromPhoneNumber,
           )
         }
@@ -258,7 +258,7 @@ async function checkButtonHeartbeat() {
 
           await db.updateButtonsSentVitalsAlerts(button.id, false)
 
-          // TODO Also send  text message to Responders and Heartbeat Phone Numbers once we know that these messages are reliable
+          // TODO Also send a text message to Responders and Heartbeat Phone Numbers once we know that these messages are reliable
         }
       }
     }


### PR DESCRIPTION
- We have found that these alerts are not too noisy, so we should get them in the hands of our Responders as soon as possible so they are apprised of the current status of their system

## Test Plan
- Deploy to dev
- Generate a RAK Button low battery message and see that it is sent to the Responder Phones and Heartbeat Phones
- Generate a RAK Gateway disconnection message and see that it is sent to the Responder Phones and Heartbeat Phones
- Generate a RAK Gateway reconnection message and see that it is sent to the Responder Phones and Heartbeat Phones