### PR TITLE
Add RSSI and SNR to the Buttons Vitals table and stop logging it (CU-2a7dcrz)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Logging RSSI and SNR values for each RAK Button message (CU-2a7dcrz).
+
 ## [12.0.0] - 2023-07-24
 
 ### Changed

--- a/server/ButtonsVital.js
+++ b/server/ButtonsVital.js
@@ -1,8 +1,10 @@
 class ButtonsVital {
-  constructor(id, batteryLevel, createdAt, button) {
+  constructor(id, batteryLevel, createdAt, snr, rssi, button) {
     this.id = id
     this.batteryLevel = batteryLevel
     this.createdAt = createdAt
+    this.snr = snr
+    this.rssi = rssi
     this.button = button
   }
 }

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -174,6 +174,8 @@ async function renderClientVitalsPage(req, res) {
           viewParams.buttons.push({
             unit: buttonsVital.button.displayName,
             batteryLevel: buttonsVital.batteryLevel !== null ? buttonsVital.batteryLevel : 'unknown',
+            rssi: buttonsVital.rssi !== null ? buttonsVital.rssi : 'unknown',
+            snr: buttonsVital.snr !== null ? buttonsVital.snr : 'unknown',
             lastSeenAt: buttonsVital.createdAt !== null ? helpers.formatDateTimeForDashboard(buttonsVital.createdAt) : 'Never',
             lastSeenAgo: buttonsVital.createdAt !== null ? await helpers.generateCalculatedTimeDifferenceString(buttonsVital.createdAt, db) : 'Never',
             isSendingAlerts: buttonsVital.button.isSendingAlerts && buttonsVital.button.client.isSendingAlerts,
@@ -243,6 +245,8 @@ async function renderVitalsPage(req, res) {
           clientId: buttonsVital.button.client.id,
           unit: buttonsVital.button.displayName,
           batteryLevel: buttonsVital.batteryLevel !== null ? buttonsVital.batteryLevel : 'unknown',
+          rssi: buttonsVital.rssi !== null ? buttonsVital.rssi : 'unknown',
+          snr: buttonsVital.snr !== null ? buttonsVital.snr : 'unknown',
           lastSeenAt: buttonsVital.createdAt !== null ? helpers.formatDateTimeForDashboard(buttonsVital.createdAt) : 'Never',
           lastSeenAgo: buttonsVital.createdAt !== null ? await helpers.generateCalculatedTimeDifferenceString(buttonsVital.createdAt, db) : 'Never',
           isSendingAlerts: buttonsVital.button.isSendingAlerts && buttonsVital.button.client.isSendingAlerts,

--- a/server/db/038-addbuttonsvitals-snrrssi.sql
+++ b/server/db/038-addbuttonsvitals-snrrssi.sql
@@ -1,0 +1,60 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 38;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        -- Don't update the buttons_vitals_cache
+        DROP TRIGGER IF EXISTS create_buttons_vitals_trigger ON buttons_vitals;
+
+        -- Add column for Button's SNR
+        ALTER TABLE buttons_vitals
+        ADD COLUMN IF NOT EXISTS snr DECIMAL;
+
+        -- Add column for Button's RSSI
+        ALTER TABLE buttons_vitals
+        ADD COLUMN IF NOT EXISTS rssi INT;
+
+        -- Add column for Button Vitals Cache's SNR
+        ALTER TABLE buttons_vitals_cache
+        ADD COLUMN IF NOT EXISTS snr DECIMAL;
+
+        -- Add column for Button Vitals Cache's RSSI
+        ALTER TABLE buttons_vitals_cache
+        ADD COLUMN IF NOT EXISTS rssi INT;
+
+        -- Re-activate trigger with new columns
+        CREATE OR REPLACE FUNCTION create_buttons_vitals_trigger_fn()
+        RETURNS TRIGGER LANGUAGE PLPGSQL AS $t$
+        BEGIN
+            INSERT INTO buttons_vitals_cache (id, button_id, battery_level, created_at, rssi, snr) 
+            VALUES (NEW.id, NEW.button_id, NEW.battery_level, NEW.created_at, NEW.rssi, NEW.snr)
+            ON CONFLICT (button_id)
+            DO UPDATE SET
+                id = NEW.id,
+                battery_level = NEW.battery_level,
+                created_at = NEW.created_at,
+                rssi = NEW.rssi,
+                snr = NEW.snr;
+            RETURN NEW;
+        END;
+        $t$;
+
+        CREATE TRIGGER create_buttons_vitals_trigger
+        BEFORE INSERT OR UPDATE ON buttons_vitals
+        FOR EACH ROW EXECUTE PROCEDURE create_buttons_vitals_trigger_fn();
+
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/mustache-templates/clientVitals.mst
+++ b/server/mustache-templates/clientVitals.mst
@@ -98,6 +98,8 @@
                             <tr class="table-header" scope="row">
                                 <th scope="col">Unit</th>
                                 <th scope="col">Battery Level</th>
+                                <th scope="col">RSSI</th>
+                                <th scope="col">SNR</th>
                                 <th scope="col">Last Seen</th>
                                 <th scope="col">Sends Alerts?</th>
                                 <th scope="col">Sends Vitals?</th>
@@ -108,6 +110,8 @@
                                 <tr class="table-data">
                                     <th scope="row">{{unit}}</th>
                                     <td>{{batteryLevel}}</td>
+                                    <td>{{rssi}}</td>
+                                    <td>{{snr}}</td>
                                     <td data-toggle="tooltip" data-placement="top" title="{{lastSeenAt}}">{{lastSeenAgo}}</td>
                                     <td>{{#isSendingAlerts}}y{{/isSendingAlerts}}{{^isSendingAlerts}}NOPE{{/isSendingAlerts}}</td>
                                     <td>{{#isSendingVitals}}y{{/isSendingVitals}}{{^isSendingVitals}}NOPE{{/isSendingVitals}}</td>

--- a/server/mustache-templates/vitals.mst
+++ b/server/mustache-templates/vitals.mst
@@ -100,6 +100,8 @@
                             <th scope="col">Client</th>
                             <th scope="col">Unit</th>
                             <th scope="col">Battery Level</th>
+                            <th scope="col">RSSI</th>
+                            <th scope="col">SNR</th>
                             <th scope="col">Last Seen</th>
                             <th scope="col">Sends Alerts?</th>
                             <th scope="col">Sends Vitals?</th>
@@ -111,6 +113,8 @@
                                 <th scope="row"><a href="/clients/{{clientId}}">{{clientName}}</a></th>
                                 <th scope="row">{{unit}}</th>
                                 <td>{{batteryLevel}}</td>
+                                <td>{{rssi}}</td>
+                                <td>{{snr}}</td>
                                 <td data-toggle="tooltip" data-placement="top" title="{{lastSeenAt}}">{{lastSeenAgo}}</td>
                                 <td>{{#isSendingAlerts}}y{{/isSendingAlerts}}{{^isSendingAlerts}}NOPE{{/isSendingAlerts}}</td>
                                 <td>{{#isSendingVitals}}y{{/isSendingVitals}}{{^isSendingVitals}}NOPE{{/isSendingVitals}}</td>

--- a/server/rak.js
+++ b/server/rak.js
@@ -23,12 +23,11 @@ async function handleButtonPress(req, res) {
     const validationErrors = Validator.validationResult(req).formatWith(helpers.formatExpressValidationErrors)
 
     if (validationErrors.isEmpty()) {
-      const { devEui, payload } = req.body
+      const { devEui, snr, rssi, payload } = req.body
       const { authorization } = req.headers
 
       const event = Buffer.from(payload, 'base64')
 
-      // TODO Remove this after we are done testing the RAK buttons
       helpers.log(JSON.stringify(req.body))
 
       if (!rakApiKeys.includes(authorization)) {
@@ -40,7 +39,7 @@ async function handleButtonPress(req, res) {
       const button = await db.getButtonWithSerialNumber(devEui)
 
       if (event[0] === EVENT_TYPE.HEARTBEAT && button !== null) {
-        await db.logButtonsVital(button.id, event[1])
+        await db.logButtonsVital(button.id, event[1], snr, rssi)
       } else if (event[0] === EVENT_TYPE.BUTTON_PRESS_4 || event[0] === EVENT_TYPE.BUTTON_PRESS_3) {
         if (button === null) {
           const errorMessage = `Bad request to ${req.path}: DevEui is not registered: '${devEui}'`

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -36,3 +36,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USE
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/035-addsentgatewayvitalsalert.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/036-addbuttonsvitalsalerts.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/037-addmorestatuses.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_USER -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/038-addbuttonsvitals-snrrssi.sql

--- a/server/test/integration/dbTest/getActiveAlertsByAlertApiKeyTest.js
+++ b/server/test/integration/dbTest/getActiveAlertsByAlertApiKeyTest.js
@@ -224,7 +224,7 @@ describe('db.js integration tests: getActiveAlertsByAlertApiKey', () => {
       updatedSession.chatbotState = CHATBOT_STATE.COMPLETED
       await db.saveSession(updatedSession)
 
-      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 1)
+      const rows = await db.getActiveAlertsByAlertApiKey(this.alertApiKey, 0)
 
       const ids = rows.map(row => row.id)
 

--- a/server/test/integration/rakTest/handleButtonPressTest.js
+++ b/server/test/integration/rakTest/handleButtonPressTest.js
@@ -310,7 +310,7 @@ describe('rak.js integration tests: handleButtonPress', () => {
         .request(server)
         .post('/rak_button_press')
         .set('authorization', rakApiKeyPrimary)
-        .send({ devEui: buttonSerialNumber, payload: 'SFA=' })
+        .send({ devEui: buttonSerialNumber, snr: 22.25, rssi: -70, payload: 'SFA=' })
     })
 
     afterEach(async () => {
@@ -325,8 +325,8 @@ describe('rak.js integration tests: handleButtonPress', () => {
       expect(helpers.logError).not.to.be.called
     })
 
-    it('should log the heartbeat', () => {
-      expect(db.logButtonsVital).to.be.calledWithExactly(this.button.id, 80)
+    it('should log the heartbeat including its battery level, RSSI, and SNR', () => {
+      expect(db.logButtonsVital).to.be.calledWithExactly(this.button.id, 80, 22.25, -70)
     })
   })
 

--- a/server/test/testingHelpers.js
+++ b/server/test/testingHelpers.js
@@ -45,6 +45,8 @@ function buttonsVitalFactory(overrides = {}) {
     overrides.id !== undefined ? overrides.id : '',
     overrides.batteryLevel !== undefined ? overrides.batteryLevel : 95,
     overrides.createdAt !== undefined ? overrides.createdAt : new Date(),
+    overrides.snr !== undefined ? overrides.snr : 14.5,
+    overrides.rssi !== undefined ? overrides.rssi : -60,
     overrides.button !== undefined ? overrides.button : buttonFactory(),
   )
 }


### PR DESCRIPTION
It'll be useful for us to record as we move to larger buildings that aren't local to us to see how strong the signal is between a button and its hub.

## Test plan
- [x] Deploy to Dev
- [x] Dashboard
   - [x] Clients Vitals Page
      - [x] Shows RSSI and SNR columns for RAK Buttons
      - [x] New rows where RSSI and SNR are not null are displayed with the value in the DB
      - [x] Old rows where RSSI and SNR are null are shown as "unknown"
      - [x] How many digits after the decimal point will SNR have at most? Should we do some rounding here?
         - It automatically rounded `13.3333333333333333333333333333333333` to `13.333333333333334`. This seems OK to me.
   - [x] Vitals Page
      - [x] Shows RSSI and SNR columns for RAK Buttons
      - [x] New rows where RSSI and SNR are not null are displayed with the value in the DB
      - [x] Old rows where RSSI and SNR are null are shown as "unknown"
      - [x] How many digits after the decimal point will SNR have at most? Should we do some rounding here?
         - It automatically rounded `13.3333333333333333333333333333333333` to `13.333333333333334`. This seems OK to me.
   - [x] RSSI and SNR from RAK Button heartbeats update `buttons_vitals` and `buttons_vitals_cache`
   - [x] RSSI and SNR from RAK Button presses are not recorded 