### PR TITLE
POST /api/message-clients (CU-w9bcb5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ matrix:
         - RADIO_BRIDGE_API_KEY_SECONDARY_TEST=secondaryKey
         - RAK_API_KEY_PRIMARY_TEST=rakKey1
         - RAK_API_KEY_SECONDARY_TEST=rakKey2
+        - PA_API_KEY_PRIMARY_TEST=bravePrimaryKey
+        - PA_API_KEY_SECONDARY_TEST=braveSecondaryKey
 
       # setup database
       before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ the code was deployed.
 
 ## [unreleased]
 
+### Added
+
+- POST /api/message-clients sends a Twilio text message to all active clients (adapted from BraveSensor) (CU-w9bcb5).
+- Unit tests for the authorize function in api.js (adapted from BraveSensor) (CU-w9bcb5).
+- Integration tests for the /api/message-clients API call (adapted from BraveSensor) (CU-w9bcb5).
+
 ### Security
 
 - Upgrade Chai and brave-alert-lib (CU-8678wgn0p).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [unreleased]
 
+### Changed
+
+- Body parsing middleware to match BraveSensor (moved from routes.js to server.js).
+
 ### Added
 
 - POST /api/message-clients sends a Twilio text message to all active clients (adapted from BraveSensor) (CU-w9bcb5).

--- a/server/api.js
+++ b/server/api.js
@@ -1,0 +1,105 @@
+/* Conventions for this API:
+ * (inherited from BraveSensor/server/api.js)
+ *  - GET method for read actions
+ *  - POST method for update actions
+ *  - PUT method for create actions
+ *  - DELETE method for delete actions
+ *
+ *  - Must contain the `braveKey` API key in the query string (for GET only) or the body (for all other methods)
+ *
+ *  - Must return a JSON object containing the following keys:
+ *    - status:   which will be either "success" or "error"
+ *    - data:     the desired JSON object, if there is one
+ *    - message:  a human-readable explanation of the error, if there was one and this is appropriate. Be careful
+ *                to not include anything that will give an attacker extra information
+ */
+
+// Third-party dependencies
+const Validator = require('express-validator')
+
+// In-house dependencies
+const { helpers, twilioHelpers } = require('brave-alert-lib')
+const db = require('./db/db')
+
+const paApiKeys = [helpers.getEnvVar('PA_API_KEY_PRIMARY'), helpers.getEnvVar('PA_API_KEY_SECONDARY')]
+
+async function authorize(req, res, next) {
+  if (paApiKeys.indexOf(req.query.braveKey) < 0 && paApiKeys.indexOf(req.body.braveKey) < 0) {
+    helpers.log(`Unauthorized request to: ${req.path}`)
+    res.status(401).send({ status: 'error', message: 'Unauthorized' })
+  } else {
+    return next()
+  }
+}
+
+const validateMessageClients = Validator.body(['braveKey', 'message']).exists()
+
+async function messageClients(req, res) {
+  const validationErrors = Validator.validationResult(req).formatWith(helpers.formatExpressValidationErrors)
+
+  try {
+    if (validationErrors.isEmpty()) {
+      const clients = await db.getActiveClients()
+      const message = req.body.message
+      const response = {
+        status: 'success',
+        data: {
+          message,
+          contacted: [],
+          failed: [],
+        },
+        message: '',
+      }
+
+      for (const client of clients) {
+        // define phoneNumbers as a Set to prevent duplicate numbers
+        const phoneNumbers = new Set()
+
+        // add responder, fallback, and heartbeat numbers to phoneNumbers
+        client.responderPhoneNumbers.forEach(phoneNumber => {
+          phoneNumbers.add(phoneNumber)
+        })
+        client.fallbackPhoneNumbers.forEach(phoneNumber => {
+          phoneNumbers.add(phoneNumber)
+        })
+        client.heartbeatPhoneNumbers.forEach(phoneNumber => {
+          phoneNumbers.add(phoneNumber)
+        })
+
+        // for each phone number of this client
+        for (const phoneNumber of phoneNumbers) {
+          // send SMS text message
+          const twilioResponse = await twilioHelpers.sendTwilioMessage(phoneNumber, client.fromPhoneNumber, message)
+          // Twilio trace object: information about the sent message
+          const twilioTraceObject = {
+            to: phoneNumber,
+            from: client.fromPhoneNumber,
+            clientId: client.id,
+            clientDisplayName: client.displayName,
+          }
+
+          // keep track of which clients were contacted and not contacted
+          if (twilioResponse === undefined || twilioResponse.status === undefined || twilioResponse.status !== 'queued') {
+            response.data.failed.push(twilioTraceObject)
+            // log entire Twilio trace object
+            helpers.log(`Failed to send Twilio message: ${JSON.stringify(twilioTraceObject)}.`)
+          } else {
+            response.data.contacted.push(twilioTraceObject)
+          }
+        }
+      }
+
+      res.status(200).send(response)
+    } else {
+      res.status(400).send({ status: 'error' })
+    }
+  } catch (e) {
+    res.status(500).send({ status: 'error' })
+  }
+}
+
+module.exports = {
+  authorize,
+  validateMessageClients,
+  messageClients,
+}

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,6 +1,3 @@
-// Third-party dependencies
-const express = require('express')
-
 // In-house dependencies
 const { clickUpHelpers } = require('brave-alert-lib')
 const dashboard = require('./dashboard')
@@ -19,12 +16,7 @@ function configureRoutes(app) {
   app.get('/vitals', dashboard.sessionChecker, dashboard.renderVitalsPage)
 
   app.post('/login', dashboard.submitLogin)
-  app.post(
-    '/pa/aws-device-registration',
-    pa.validateAwsDeviceRegistration,
-    clickUpHelpers.clickUpChecker,
-    pa.handleAwsDeviceRegistration,
-  )
+  app.post('/pa/aws-device-registration', pa.validateAwsDeviceRegistration, clickUpHelpers.clickUpChecker, pa.handleAwsDeviceRegistration)
   app.post('/pa/buttons-twilio-number', pa.validateButtonsTwilioNumber, clickUpHelpers.clickUpChecker, pa.handleButtonsTwilioNumber)
   app.post('/rak_button_press', rak.validateButtonPress, rak.handleButtonPress)
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -8,8 +8,6 @@ const pa = require('./pa')
 const rak = require('./rak')
 const api = require('./api')
 
-const jsonBodyParser = express.json()
-
 function configureRoutes(app) {
   app.get('/', dashboard.sessionChecker, dashboard.redirectToHomePage)
   app.get('/dashboard', dashboard.sessionChecker, dashboard.renderDashboardPage)
@@ -23,15 +21,14 @@ function configureRoutes(app) {
   app.post('/login', dashboard.submitLogin)
   app.post(
     '/pa/aws-device-registration',
-    jsonBodyParser,
     pa.validateAwsDeviceRegistration,
     clickUpHelpers.clickUpChecker,
     pa.handleAwsDeviceRegistration,
   )
-  app.post('/pa/buttons-twilio-number', jsonBodyParser, pa.validateButtonsTwilioNumber, clickUpHelpers.clickUpChecker, pa.handleButtonsTwilioNumber)
-  app.post('/rak_button_press', jsonBodyParser, rak.validateButtonPress, rak.handleButtonPress)
+  app.post('/pa/buttons-twilio-number', pa.validateButtonsTwilioNumber, clickUpHelpers.clickUpChecker, pa.handleButtonsTwilioNumber)
+  app.post('/rak_button_press', rak.validateButtonPress, rak.handleButtonPress)
 
-  app.post('/api/message-clients', jsonBodyParser, api.validateMessageClients, api.authorize, api.messageClients)
+  app.post('/api/message-clients', api.validateMessageClients, api.authorize, api.messageClients)
 }
 
 module.exports = {

--- a/server/routes.js
+++ b/server/routes.js
@@ -6,6 +6,7 @@ const { clickUpHelpers } = require('brave-alert-lib')
 const dashboard = require('./dashboard')
 const pa = require('./pa')
 const rak = require('./rak')
+const api = require('./api')
 
 const jsonBodyParser = express.json()
 
@@ -29,6 +30,8 @@ function configureRoutes(app) {
   )
   app.post('/pa/buttons-twilio-number', jsonBodyParser, pa.validateButtonsTwilioNumber, clickUpHelpers.clickUpChecker, pa.handleButtonsTwilioNumber)
   app.post('/rak_button_press', jsonBodyParser, rak.validateButtonPress, rak.handleButtonPress)
+
+  app.post('/api/message-clients', jsonBodyParser, api.validateMessageClients, api.authorize, api.messageClients)
 }
 
 module.exports = {

--- a/server/server.js
+++ b/server/server.js
@@ -22,6 +22,8 @@ const braveAlerter = new BraveAlerterConfigurator().createBraveAlerter()
 
 // Start and configure Express App
 const app = express()
+
+app.use(express.json()) // Body Parser Middleware
 app.use(express.urlencoded({ extended: true }))
 app.use(cors()) // Cors Middleware (Cross Origin Resource Sharing)
 dashboard.setupDashboardSessions(app)

--- a/server/test/integration/apiTest/messageClientsTest.js
+++ b/server/test/integration/apiTest/messageClientsTest.js
@@ -1,0 +1,328 @@
+// Third-party dependencies
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+const sinonChai = require('sinon-chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+
+// In-house dependencies
+const { factories, helpers, twilioHelpers } = require('brave-alert-lib')
+const { buttonDBFactory } = require('../../testingHelpers')
+const { server, db } = require('../../../server')
+
+chai.use(chaiHttp)
+chai.use(sinonChai)
+
+const expect = chai.expect
+const sandbox = sinon.createSandbox()
+const braveKey = helpers.getEnvVar('PA_API_KEY_PRIMARY')
+const badBraveKey = 'badbravekey'
+const message = 'Hello, world!'
+const testFromPhoneNumber = '+11234567890'
+
+// information about clients that should be contacted
+const testExpectPhoneNumbers = ['+11111111111', '+12222222222', '+13333333333', '+14444444444']
+// contents are set once clients are created from factories.clientDBFactory
+const testExpectResponse = []
+
+// information about clients that should not be contacted
+const testNotExpectPhoneNumbers = ['+15555555555', '+16666666666', '+17777777777', '+18888888888']
+// contents are set once clients are created from factories.clientDBFactory
+const testNotExpectResponse = []
+
+describe('api.js integration tests: messageClients', () => {
+  beforeEach(async () => {
+    await db.clearTables()
+
+    // active clients
+    const activeClients = []
+
+    // clear these arrays
+    testExpectResponse.length = 0
+    testNotExpectResponse.length = 0
+
+    // has responder phone number
+    activeClients.push(
+      await factories.clientDBFactory(db, {
+        displayName: 'Test Client Responder',
+        responderPhoneNumbers: [testExpectPhoneNumbers[0]],
+        fallbackPhoneNumbers: [],
+        heartbeatPhoneNumbers: [],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: true,
+        isSendingVitals: true,
+      }),
+      await factories.clientDBFactory(db, {
+        displayName: 'Test Client Fallback',
+        responderPhoneNumbers: [],
+        fallbackPhoneNumbers: [testExpectPhoneNumbers[1]],
+        heartbeatPhoneNumbers: [],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: true,
+        isSendingVitals: true,
+      }),
+      await factories.clientDBFactory(db, {
+        displayName: 'Test Client Heartbeat',
+        responderPhoneNumbers: [],
+        fallbackPhoneNumbers: [],
+        heartbeatPhoneNumbers: [testExpectPhoneNumbers[2]],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: true,
+        isSendingVitals: true,
+      }),
+      await factories.clientDBFactory(db, {
+        displayName: 'Test Client Duplicates',
+        responderPhoneNumbers: [testExpectPhoneNumbers[3]],
+        fallbackPhoneNumbers: [testExpectPhoneNumbers[3]],
+        heartbeatPhoneNumbers: [testExpectPhoneNumbers[3]],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: true,
+        isSendingVitals: true,
+      }),
+    )
+    for (let i = 0; i < 4; i += 1) {
+      testExpectResponse.push({
+        to: testExpectPhoneNumbers[i],
+        from: testFromPhoneNumber,
+        clientId: activeClients[i].id,
+        clientDisplayName: activeClients[i].displayName,
+      })
+      await buttonDBFactory(db, {
+        clientId: activeClients[i].id,
+        displayName: `Button for ${activeClients[i].displayName}`,
+        buttonSerialNumber: `Button${activeClients[i].id.substr(0, 8)}`,
+        isSendingAlerts: true,
+        isSendingVitals: true,
+      })
+    }
+
+    // non-active clients
+    const nonActiveClients = []
+
+    const testClientNoButton = await factories.clientDBFactory(db, {
+      displayName: 'Test Client No Button',
+      responderPhoneNumbers: [testNotExpectPhoneNumbers[0]],
+      fallbackPhoneNumbers: [],
+      heartbeatPhoneNumbers: [],
+      fromPhoneNumber: testFromPhoneNumber,
+      isSendingAlerts: true,
+      isSendingVitals: true,
+    })
+    testNotExpectResponse.push({
+      to: testNotExpectPhoneNumbers[0],
+      from: testFromPhoneNumber,
+      clientId: testClientNoButton.id,
+      clientDisplayName: testClientNoButton.displayName,
+    })
+
+    nonActiveClients.push(
+      await factories.clientDBFactory(db, {
+        displayName: "Test Client Don't Send Alerts",
+        responderPhoneNumbers: [],
+        fallbackPhoneNumbers: [testNotExpectPhoneNumbers[1]],
+        heartbeatPhoneNumbers: [],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: false,
+        isSendingVitals: true,
+      }),
+      await factories.clientDBFactory(db, {
+        displayName: "Test Client Don't Send Vitals",
+        responderPhoneNumbers: [],
+        fallbackPhoneNumbers: [],
+        heartbeatPhoneNumbers: [testNotExpectPhoneNumbers[2]],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: true,
+        isSendingVitals: false,
+      }),
+      await factories.clientDBFactory(db, {
+        displayName: "Test Client Don't Send",
+        responderPhoneNumbers: [testNotExpectPhoneNumbers[3]],
+        fallbackPhoneNumbers: [testNotExpectPhoneNumbers[3]],
+        heartbeatPhoneNumbers: [testNotExpectPhoneNumbers[3]],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: false,
+        isSendingVitals: false,
+      }),
+    )
+
+    // create buttons for all non-active clients
+    for (let i = 0; i < 3; i += 1) {
+      testNotExpectResponse.push({
+        to: testNotExpectPhoneNumbers[i + 1],
+        from: testFromPhoneNumber,
+        clientId: nonActiveClients[i].id,
+        clientDisplayName: nonActiveClients[i].displayName,
+      })
+      await buttonDBFactory(db, {
+        clientId: nonActiveClients[i].id,
+        displayName: `Button for ${nonActiveClients[i].displayName}`,
+        buttonSerialNumber: `Button${nonActiveClients[i].id.substr(0, 8)}`,
+        isSendingAlerts: Math.round(Math.random()),
+        isSendingVitals: Math.round(Math.random()),
+      })
+    }
+
+    this.agent = chai.request.agent(server)
+  })
+
+  afterEach(async () => {
+    await db.clearTables()
+    this.agent.close()
+  })
+
+  describe('for a request that uses the correct PA API key, and where Twilio is operating correctly', () => {
+    beforeEach(async () => {
+      // stub twilioHelpers.sendTwilioMessage
+      sandbox.stub(twilioHelpers, 'sendTwilioMessage').returns({ status: 'queued' })
+    })
+
+    afterEach(async () => {
+      sandbox.restore()
+    })
+
+    it('should respond with status 200 (OK)', async () => {
+      const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      expect(response).to.have.status(200)
+    })
+
+    it('should respond with the same message that was posted', async () => {
+      const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.message).to.be.a('string').that.equals(message)
+    })
+
+    it('should attempt to message all active clients', async () => {
+      await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      testExpectPhoneNumbers.forEach(pn => {
+        expect(twilioHelpers.sendTwilioMessage).to.be.calledWith(pn, testFromPhoneNumber, message)
+      })
+    })
+
+    it('should not attempt to message any non-active clients', async () => {
+      await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      testNotExpectPhoneNumbers.forEach(pn => {
+        expect(twilioHelpers.sendTwilioMessage).to.not.be.calledWith(pn, testFromPhoneNumber, message)
+      })
+    })
+
+    it('should respond with contacted client information in the `contacted` field of the response body', async () => {
+      const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.contacted).to.be.an('array').that.has.deep.members(testExpectResponse)
+    })
+
+    it('should respond with no clients in the `failed` field of the response body', async () => {
+      const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.failed).to.be.an('array').that.is.empty
+    })
+  })
+
+  describe('for a request that uses the correct PA API key, and where Twilio is not operating correctly', () => {
+    beforeEach(async () => {
+      // stub twilioHelpers.sendTwilioMessage
+      sandbox.stub(twilioHelpers, 'sendTwilioMessage').returns(undefined)
+    })
+
+    afterEach(async () => {
+      sandbox.restore()
+    })
+
+    it('should respond with status 200 (OK)', async () => {
+      const response = await this.agent.post('/api/message-clients?test=1').send({ braveKey, message })
+
+      expect(response).to.have.status(200)
+    })
+
+    it('should respond with the same message that was posted', async () => {
+      const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.message).to.be.a('string').that.equal(message)
+    })
+
+    it('should attempt to message all active clients', async () => {
+      await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      testExpectPhoneNumbers.forEach(pn => {
+        expect(twilioHelpers.sendTwilioMessage).to.be.calledWith(pn, testFromPhoneNumber, message)
+      })
+    })
+
+    it('should not attempt to message any non-active clients', async () => {
+      await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      testNotExpectPhoneNumbers.forEach(pn => {
+        expect(twilioHelpers.sendTwilioMessage).to.not.be.calledWith(pn, testFromPhoneNumber, message)
+      })
+    })
+
+    it('should respond with no clients in the `contacted` field of the response body', async () => {
+      const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.contacted).to.be.an('array').that.is.empty
+    })
+
+    it('should respond with active clients in the `failed` field of the response body', async () => {
+      const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.failed).to.be.an('array').that.has.deep.members(testExpectResponse)
+    })
+  })
+
+  describe('for a request that uses an incorrect PA API key', () => {
+    beforeEach(async () => {
+      // stub twilioHelpers.sendTwilioMessage;
+      // it shouldn't be called, so don't bother with providing a return value
+      sandbox.stub(twilioHelpers, 'sendTwilioMessage')
+    })
+
+    afterEach(async () => {
+      sandbox.restore()
+    })
+
+    it('should respond with status 401 (Unauthorized)', async () => {
+      const response = await this.agent.post('/api/message-clients').send({ braveKey: badBraveKey, message })
+
+      expect(response).to.have.status(401)
+    })
+
+    it('should not message anyone', async () => {
+      await this.agent.post('/api/message-clients').send({ braveKey: badBraveKey, message })
+
+      expect(twilioHelpers.sendTwilioMessage).to.not.be.called
+    })
+  })
+
+  describe('for a request that does not provide any PA API key', () => {
+    beforeEach(async () => {
+      // stub twilioHelpers.sendTwilioMessage;
+      // it shouldn't be called, so don't bother with providing a return value
+      sandbox.stub(twilioHelpers, 'sendTwilioMessage')
+    })
+
+    afterEach(async () => {
+      sandbox.restore()
+    })
+
+    it('should respond with status 401 (Unauthorized)', async () => {
+      const response = await this.agent.post('/api/message-clients').send({ message })
+
+      expect(response).to.have.status(401)
+    })
+
+    it('should not message anyone', async () => {
+      await this.agent.post('/api/message-clients').send({ message })
+
+      expect(twilioHelpers.sendTwilioMessage).to.not.be.called
+    })
+  })
+})

--- a/server/test/unit/apiTest/authorizeTest.js
+++ b/server/test/unit/apiTest/authorizeTest.js
@@ -1,0 +1,199 @@
+// Third-party dependencies
+const { expect, use } = require('chai')
+const { describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+
+// In-house dependencies
+const { helpers } = require('brave-alert-lib')
+
+const api = require('../../../api')
+
+// Configure Chai
+use(sinonChai)
+
+const sandbox = sinon.createSandbox()
+
+function authorize_next() {
+  helpers.log('authorize_next')
+}
+
+function mockRequest(_req) {
+  const req = _req
+  return req
+}
+
+function mockResponse() {
+  const res = {}
+  res.status = sinon.stub().returns(res)
+  res.send = sinon.stub().returns(res)
+  return res
+}
+
+describe('api.js unit tests: authorize', () => {
+  beforeEach(() => {
+    sandbox.spy(helpers, 'logSentry')
+    sandbox.spy(helpers, 'logError')
+    sandbox.spy(helpers, 'log')
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('when a request provides the primary PA API key in the query string of the request', () => {
+    beforeEach(async () => {
+      // create fake request object that implements the necessary members
+      const req = mockRequest({
+        query: { braveKey: helpers.getEnvVar('PA_API_KEY_PRIMARY') },
+        body: {}, // empty
+        path: 'test_path',
+      })
+      this.res = mockResponse()
+
+      await api.authorize(req, this.res, authorize_next)
+    })
+
+    it('should call the authorize_next function', () => {
+      expect(helpers.log).to.have.been.calledWith('authorize_next')
+    })
+  })
+
+  describe('when a request provides the primary PA API key in the body of the request', () => {
+    beforeEach(async () => {
+      // create fake request object that implements the necessary members
+      const req = mockRequest({
+        query: {}, // empty
+        body: { braveKey: helpers.getEnvVar('PA_API_KEY_PRIMARY') },
+        path: 'test_path',
+      })
+      this.res = mockResponse()
+
+      await api.authorize(req, this.res, authorize_next)
+    })
+
+    it('should call the authorize_next function', () => {
+      expect(helpers.log).to.have.been.calledWith('authorize_next')
+    })
+  })
+
+  describe('when a request provides the secondary PA API key in the query string of the request', () => {
+    beforeEach(async () => {
+      // create fake request object that implements the necessary members
+      const req = mockRequest({
+        query: { braveKey: helpers.getEnvVar('PA_API_KEY_SECONDARY') },
+        body: {}, // empty
+        path: 'test_path',
+      })
+      this.res = mockResponse()
+
+      await api.authorize(req, this.res, authorize_next)
+    })
+
+    it('should call the authorize_next function', () => {
+      expect(helpers.log).to.have.been.calledWith('authorize_next')
+    })
+  })
+
+  describe('when a request provides the secondary PA API key in the body of the request', () => {
+    beforeEach(async () => {
+      // create fake request object that implements the necessary members
+      const req = mockRequest({
+        query: {}, // empty
+        body: { braveKey: helpers.getEnvVar('PA_API_KEY_SECONDARY') },
+        path: 'test_path',
+      })
+      this.res = mockResponse()
+
+      await api.authorize(req, this.res, authorize_next)
+    })
+
+    it('should call the authorize_next function', () => {
+      expect(helpers.log).to.have.been.calledWith('authorize_next')
+    })
+  })
+
+  describe('when a request provides an invalid PA API key in the query string of the request', () => {
+    beforeEach(async () => {
+      // create fake request object that implements the necessary members
+      const req = mockRequest({
+        query: { braveKey: 'INVALID_API_KEY' },
+        body: {}, // empty
+        path: 'test_path',
+      })
+      this.res = mockResponse()
+
+      await api.authorize(req, this.res, authorize_next)
+    })
+
+    it('should not call the authorize_next function', () => {
+      expect(helpers.log).to.not.have.been.calledWith('authorize_next')
+    })
+
+    it('should result in status 401 (Unauthorized)', () => {
+      expect(this.res.status).to.have.been.calledWith(401)
+    })
+  })
+
+  describe('when a request provides an invalid PA API key in the body of the request', () => {
+    beforeEach(async () => {
+      // create fake request object that implements the necessary members
+      const req = mockRequest({
+        query: {}, // empty
+        body: { braveKey: 'INVALID_API_KEY' },
+        path: 'test_path',
+      })
+      this.res = mockResponse()
+
+      await api.authorize(req, this.res, authorize_next)
+    })
+
+    it('should not call the authorize_next function', () => {
+      expect(helpers.log).to.not.have.been.calledWith('authorize_next')
+    })
+
+    it('should result in status 401 (Unauthorized)', () => {
+      expect(this.res.status).to.have.been.calledWith(401)
+    })
+  })
+
+  describe('when a request does not provide a PA API key at all', () => {
+    beforeEach(async () => {
+      // create fake request object that implements the necessary members
+      const req = mockRequest({
+        query: {}, // empty
+        body: {}, // empty
+        path: 'test_path',
+      })
+      this.res = mockResponse()
+
+      await api.authorize(req, this.res, authorize_next)
+    })
+
+    it('should not call the authorize_next function', () => {
+      expect(helpers.log).to.not.have.been.calledWith('authorize_next')
+    })
+
+    it('should result in status 401 (Unauthorized)', () => {
+      expect(this.res.status).to.have.been.calledWith(401)
+    })
+  })
+
+  describe('when a request provides the primary PA API key in both the query and the body', () => {
+    beforeEach(async () => {
+      // create fake request object that implements the necessary members
+      const req = mockRequest({
+        query: { braveKey: helpers.getEnvVar('PA_API_KEY_PRIMARY') },
+        body: { braveKey: helpers.getEnvVar('PA_API_KEY_PRIMARY') },
+        path: 'test_path',
+      })
+      this.res = mockResponse()
+
+      await api.authorize(req, this.res, authorize_next)
+    })
+
+    it('should call the authorize_next function', () => {
+      expect(helpers.log).to.have.been.calledWith('authorize_next')
+    })
+  })
+})


### PR DESCRIPTION
The API call /api/message-clients sends text messages to active clients.

It works as follows:

For all clients that are sending vitals, sending alerts, and have at least one button that is sending vitals and sending alerts, send a Twilio message containing the message that was POSTed to /api/message-clients.
Requires proper submission of the Particle Accelerator API key (braveKey); this is because the API call is intended to be called from PA.

Upon successful submission of the API key, the server will respond with a JSON object containing information about contacted/failed clients:

```json
{
    "status": "success",
    "message": "This is the text message that was sent!",
    "contacted": [
        {
            "to": "+11111111111",
            "from": "+12222222222",
            "clientId": "01234567-89ab-cdef-0123-456789abcdef",
            "clientDisplayName": "Test Client"
        },
        {
            "to": "+13333333333",
            "from": "+14444444444",
            "clientId": "abcdef01-2345-6789-abcd-ef0123456789",
            "clientDisplayName": "Test Client"
        }
    ],
    "failed": []
}
```

Where `contacted` and `failed` are arrays of objects containing `to`, `from`, `clientId`, and `clientDisplayName` members.
All objects in `contacted` were successfully contacted; Twilio gave the status of "queued".
All objects in `failed` weren't successfully contacted; Twilio rejected the request, and did not queue the message.
Requests can fail for a variety of reasons, for example, an incorrect `from` phone number.

This response information is intended to be displayed in the PA dashboard.

Additionally, upon failure to send a Twilio message, the following message will be logged internally; i.e., visible from the CloudWatch dashboard in AWS:

```
Failed to send Twilio message: {"to":"+11111111111","from":"+12222222222","clientId":"01234567-89ab-cdef-0123-456789abcdef","clientDisplayName":"Test Client"}.
```

Test plan:
- [x] write integration tests to make sure /api/message-clients parses active clients properly
  - [x] for a request that uses the correct PA API key, and where Twilio is operating correctly
    - [x] should respond with status 200 (OK)
    - [x] should respond with the same message that was posted
    - [x] should attempt to message all active clients
    - [x] should not attempt to message any non-active clients
    - [x] should respond with contacted clients in the `contacted` field of the response body
    - [x] should respond with no clients in the `failed` field of the response body
  - [x] for a request that uses the correct PA API key, and where Twilio is not operating correctly
    - [x] should respond with status 200 (OK)
    - [x] should respond with the same message that was posted
    - [x] should attempt to message all active clients
    - [x] should not attempt to message any non-active clients
    - [x] should respond with no clients in the `contacted` field of the response body
    - [x] should respond with active clients in the `failed` field of the response body
  - [x] for a request that uses the incorrect PA API key
    - [x] should respond with status 401 (Unauthorized)
    - [x] should not message anyone
  - [x] for a request that does not provide any PA API key
    - [x] should respond with status 401 (Unauthorized)
    - [x] should not message anyone
- [x] create several clients and buttons on local database; test that this API call decides which clients to message properly
- [x] use this API call on the development server and prove that it works properly with real Twilio API keys