### PR TITLE
Updated PA API routes to use googleHelpers (CU-8679128d6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ the code was deployed.
 - Body parsing middleware to match BraveSensor (moved from routes.js to server.js).
 - Updated production deployment instructions in README.
 - PA API routes /pa/aws-device-registration, /pa/buttons-twilio-number to use googleHelpers.paAuthorize instead of clickUpHelpers.clickUpChecker (CU-8679128d6).
-- Upgraded `brave-alert-lib` to v10.3.0 (CU-8679128d6).
+- Upgraded `brave-alert-lib` to v10.3.1 (CU-8679128d6).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ the code was deployed.
 
 - Body parsing middleware to match BraveSensor (moved from routes.js to server.js).
 - Updated production deployment instructions in README.
+- PA API routes /pa/aws-device-registration, /pa/buttons-twilio-number to use googleHelpers.paAuthorize instead of clickUpHelpers.clickUpChecker (CU-8679128d6).
+- Upgraded `brave-alert-lib` to v10.3.0 (CU-8679128d6).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,17 @@ the code was deployed.
 
 ## [unreleased]
 
+### Changed
+
+- PA API routes /pa/aws-device-registration, /pa/buttons-twilio-number to use googleHelpers.paAuthorize instead of clickUpHelpers.clickUpChecker (CU-8679128d6).
+- Upgraded `brave-alert-lib` to v10.3.1 (CU-8679128d6).
+
 ## [13.2.0] - 2023-11-23
 
 ### Changed
 
 - Body parsing middleware to match BraveSensor (moved from routes.js to server.js).
 - Updated production deployment instructions in README.
-- PA API routes /pa/aws-device-registration, /pa/buttons-twilio-number to use googleHelpers.paAuthorize instead of clickUpHelpers.clickUpChecker (CU-8679128d6).
-- Upgraded `brave-alert-lib` to v10.3.1 (CU-8679128d6).
 
 ### Added
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -145,3 +145,13 @@ PA_API_KEY_PRIMARY=MyLongKey
 PA_API_KEY_PRIMARY_TEST=MyLongKey
 PA_API_KEY_SECONDARY=MyLongKeyBackup
 PA_API_KEY_SECONDARY_TEST=MyLongKeyBackup
+
+# The client ID of PA (for use in brave-alert-lib)
+# Get this from Google Cloud --> Brave PA Sign-In --> APIs & Services --> Credentials --> Web ID / Web ID (dev)
+PA_CLIENT_ID=fakeclientid.apps.googleusercontent.com
+PA_CLIENT_ID_TEST=fakeclientid.apps.googleusercontent.com
+
+# The client secret of PA (for use in brave-alert-lib)
+# Get this from Google Cloud --> Brave PA Sign-In --> APIs & Services --> Credentials --> Web ID / Web ID (dev)
+PA_CLIENT_SECRET=fakeclientsecret
+PA_CLIENT_SECRET_TEST=fakeclientsecret

--- a/server/pa.js
+++ b/server/pa.js
@@ -7,7 +7,7 @@ const aws = require('./aws')
 
 const paApiKeys = [helpers.getEnvVar('PA_API_KEY_PRIMARY'), helpers.getEnvVar('PA_API_KEY_SECONDARY')]
 
-const validateButtonsTwilioNumber = Validator.body(['braveKey', 'areaCode', 'locationID', 'clickupToken']).trim().notEmpty()
+const validateButtonsTwilioNumber = Validator.body(['braveKey', 'areaCode', 'locationID', 'googleIdToken']).trim().notEmpty()
 
 async function handleButtonsTwilioNumber(req, res) {
   const validationErrors = Validator.validationResult(req).formatWith(helpers.formatExpressValidationErrors)
@@ -34,7 +34,7 @@ async function handleButtonsTwilioNumber(req, res) {
   }
 }
 
-const validateAwsDeviceRegistration = Validator.body(['deviceEUI', 'targetName', 'clickupToken', 'braveKey']).trim().notEmpty()
+const validateAwsDeviceRegistration = Validator.body(['deviceEUI', 'targetName', 'googleIdToken', 'braveKey']).trim().notEmpty()
 
 async function handleAwsDeviceRegistration(req, res) {
   const validationErrors = Validator.validationResult(req).formatWith(helpers.formatExpressValidationErrors)

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-iot": "^3.360.0",
         "@aws-sdk/client-iot-wireless": "^3.360.0",
-        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v10.3.1",
+        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v10.3.1",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "express": "^4.17.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-iot": "^3.360.0",
         "@aws-sdk/client-iot-wireless": "^3.360.0",
-        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v10.3.0",
+        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v10.3.1",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "express": "^4.17.1",
@@ -2666,8 +2666,8 @@
       }
     },
     "node_modules/brave-alert-lib": {
-      "version": "10.3.0",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#cbcdf167051f65c71f0d2ea8564084004329db8c",
+      "version": "10.3.1",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#fd0aa031c23500ad88709ce938e6c919b3c0667b",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-iot": "^3.360.0",
         "@aws-sdk/client-iot-wireless": "^3.360.0",
-        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v10.2.0",
+        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v10.3.0",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "express": "^4.17.1",
@@ -2552,6 +2552,33 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2639,8 +2666,8 @@
       }
     },
     "node_modules/brave-alert-lib": {
-      "version": "10.2.0",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#7773aca576752a29d3244c75b8764e8c1e51ef3e",
+      "version": "10.3.0",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#cbcdf167051f65c71f0d2ea8564084004329db8c",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
@@ -2649,6 +2676,7 @@
         "dotenv": "^7.0.0",
         "express": "^4.17.1",
         "express-validator": "^6.10.0",
+        "google-auth-library": "^9.2.0",
         "luxon": "^2.5.2",
         "twilio": "^4.7.1"
       }
@@ -4007,6 +4035,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4337,6 +4370,55 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.1.tgz",
+      "integrity": "sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4465,6 +4547,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.2.0.tgz",
+      "integrity": "sha512-1oV3p0JhNEhVbj26eF3FAJcv9MXXQt4S0wcvKZaDbl4oHq5V3UJoSbsGZGQNcjoCdhW4kDSwOs11wLlHog3fgQ==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.0.0",
+        "gcp-metadata": "^6.0.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -4490,6 +4607,37 @@
       "dev": true,
       "engines": {
         "node": ">=4.x"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.0.1.tgz",
+      "integrity": "sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/gtoken/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/has": {
@@ -5000,7 +5148,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -5240,6 +5387,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -5846,6 +6001,25 @@
       "dev": true,
       "dependencies": {
         "isarray": "0.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-preload": {
@@ -7450,6 +7624,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -7780,6 +7959,20 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aws-sdk/client-iot": "^3.360.0",
     "@aws-sdk/client-iot-wireless": "^3.360.0",
-    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v10.3.1",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v10.3.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aws-sdk/client-iot": "^3.360.0",
     "@aws-sdk/client-iot-wireless": "^3.360.0",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v10.2.0",
+    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v10.3.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aws-sdk/client-iot": "^3.360.0",
     "@aws-sdk/client-iot-wireless": "^3.360.0",
-    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v10.3.0",
+    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v10.3.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,5 +1,5 @@
 // In-house dependencies
-const { clickUpHelpers } = require('brave-alert-lib')
+const { googleHelpers } = require('brave-alert-lib')
 const dashboard = require('./dashboard')
 const pa = require('./pa')
 const rak = require('./rak')
@@ -16,8 +16,8 @@ function configureRoutes(app) {
   app.get('/vitals', dashboard.sessionChecker, dashboard.renderVitalsPage)
 
   app.post('/login', dashboard.submitLogin)
-  app.post('/pa/aws-device-registration', pa.validateAwsDeviceRegistration, clickUpHelpers.clickUpChecker, pa.handleAwsDeviceRegistration)
-  app.post('/pa/buttons-twilio-number', pa.validateButtonsTwilioNumber, clickUpHelpers.clickUpChecker, pa.handleButtonsTwilioNumber)
+  app.post('/pa/aws-device-registration', pa.validateAwsDeviceRegistration, googleHelpers.paAuthorize, pa.handleAwsDeviceRegistration)
+  app.post('/pa/buttons-twilio-number', pa.validateButtonsTwilioNumber, googleHelpers.paAuthorize, pa.handleButtonsTwilioNumber)
   app.post('/rak_button_press', rak.validateButtonPress, rak.handleButtonPress)
 
   app.post('/api/message-clients', api.validateMessageClients, api.authorize, api.messageClients)


### PR DESCRIPTION
This PR updates the PA API routes `/pa/aws-device-registration` and `/pa/buttons-twilio-number` to use `googleHelpers.paAuthorize` instead of `clickUpHelpers.clickUpChecker`.
It also upgrades `brave-alert-lib` to v10.3.1, which removes the `clickUpHelpers` export, with `googleHelpers` being its replacement.

Test plan:
- [x] Passes existing test cases
- [x] PA API routes work as expected with `particle-accelerator` updates