### PR TITLE
Add Route to Check the Database Connection (CU-86dqkw7ef)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+## Added
+
+- PA route /pa/health to check if database connection is working as expected (CU-86dqkw7ef).
+
 ## [13.3.0] - 2023-12-06
 
 ### Added

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1287,6 +1287,38 @@ async function getCurrentTime(pgClient) {
   }
 }
 
+// Checks the database connection, if not able to connect will throw an error
+async function getCurrentTimeForHealthCheck() {
+  if (helpers.isDbLogging()) {
+    helpers.log(`STARTED: getCurrentTimeForHealthCheck`)
+  }
+
+  let pgClient = null
+
+  try {
+    pgClient = await pool.connect()
+    if (helpers.isDbLogging()) {
+      helpers.log(`CONNECTED: getCurrentTimeForHealthCheck`)
+    }
+
+    const results = await pgClient.query(`SELECT NOW()`)
+    return results.rows[0].now
+  } catch (err) {
+    helpers.logError(`Error running the getCurrentTimeForHealthCheck query: ${err}`)
+    throw err
+  } finally {
+    try {
+      pgClient.release()
+    } catch (err) {
+      helpers.logError(`getCurrentTimeForHealthCheck: Error releasing client: ${err}`)
+    }
+
+    if (helpers.isDbLogging()) {
+      helpers.log(`COMPLETED: getCurrentTimeForHealthCheck`)
+    }
+  }
+}
+
 async function close() {
   try {
     await pool.end()
@@ -1348,6 +1380,7 @@ module.exports = {
   getButtons,
   getButtonWithSerialNumber,
   getCurrentTime,
+  getCurrentTimeForHealthCheck,
   getDataForExport,
   getHistoricAlertsByAlertApiKey,
   getClients,

--- a/server/routes.js
+++ b/server/routes.js
@@ -18,6 +18,7 @@ function configureRoutes(app) {
   app.post('/pa/aws-device-registration', pa.validateAwsDeviceRegistration, googleHelpers.paAuthorize, pa.handleAwsDeviceRegistration)
   app.post('/pa/buttons-twilio-number', pa.validateButtonsTwilioNumber, googleHelpers.paAuthorize, pa.handleButtonsTwilioNumber)
   app.post('/pa/message-clients', pa.validateMessageClients, googleHelpers.paAuthorize, pa.handleMessageClients)
+  app.post('/pa/health', pa.validateCheckDatabaseConnection, googleHelpers.paAuthorize, pa.handleCheckDatabaseConnection)
   app.post('/rak_button_press', rak.validateButtonPress, rak.handleButtonPress)
 }
 

--- a/server/test/unit/paTest/handleCheckDatabaseConnectionTest.js
+++ b/server/test/unit/paTest/handleCheckDatabaseConnectionTest.js
@@ -1,0 +1,76 @@
+// Third-party dependencies
+const { expect, use } = require('chai')
+const { describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+
+// In-house dependencies
+const { helpers } = require('brave-alert-lib')
+const { mockResponse } = require('../../testingHelpers')
+const pa = require('../../../pa')
+const db = require('../../../db/db')
+
+const testGoogleIdToken = 'google-id-token'
+const braveKey = helpers.getEnvVar('PA_API_KEY_PRIMARY')
+
+use(sinonChai)
+const sandbox = sinon.createSandbox()
+
+describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
+  beforeEach(() => {
+    this.res = mockResponse(sandbox)
+    sandbox.spy(helpers, 'logError')
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('for a valid request where the database function successfully returns a client', () => {
+    beforeEach(async () => {
+      sandbox.stub(db, 'getCurrentTimeForHealthCheck').returns('2023-12-11 12:34:56.789+00')
+      await pa.handleCheckDatabaseConnection(
+        {
+          body: { braveKey, googleIdToken: testGoogleIdToken },
+        },
+        this.res,
+      )
+    })
+    it('should respond with status 200', () => {
+      expect(this.res.status).to.be.calledWith(200)
+    })
+  })
+
+  describe('for an request with an invalid braveKey', () => {
+    beforeEach(async () => {
+      sandbox.stub(db, 'getCurrentTimeForHealthCheck')
+      await pa.handleCheckDatabaseConnection(
+        {
+          body: { braveKey: 'invalidKey', googleIdToken: testGoogleIdToken },
+        },
+        this.res,
+      )
+    })
+    it('should respond with status 401', () => {
+      expect(this.res.status).to.be.calledWith(401)
+    })
+  })
+
+  describe('for a valid request where an error occurs during database access', () => {
+    beforeEach(async () => {
+      sandbox.stub(db, 'getCurrentTimeForHealthCheck').rejects(new Error('fake error'))
+      await pa.handleCheckDatabaseConnection(
+        {
+          body: { braveKey, googleIdToken: testGoogleIdToken },
+        },
+        this.res,
+      )
+    })
+    it('should log the error', () => {
+      expect(helpers.logError).to.be.called
+    })
+    it('should respond with status 503', () => {
+      expect(this.res.status).to.be.calledWith(503)
+    })
+  })
+})


### PR DESCRIPTION
## PA Route - Checking Database Connection
This PR is part of the broader Clickup task to create a system status page in PA. These changes include creating a route to check if the BraveButtons database connection is working as expected (by running one simple db query). PA will hit this route with a `googleIdToken` and `braveKey`. Upon getting the response, PA will  display a green icon if the connection is working or a red icon if it is not. 

### Test Plan:
- Unit Test for `pa.handleCheckDatabaseConnection`
   - [x] Valid request with successful database connection
   - [x] Request with invalid braveKey
   - [x] Valid request with database error
- Other Testing
   - [x] Test PA route with local environment where server is working but database is not connnected (status 503)
   - [x] Travis Passes
   - [x] Deploy to Dev - Test with Postman
      - [x] Valid API Key & GoogleIdToken
      - [x] Invalid API Key & valid GoogleIdToken
      - [x] Valid API Key & invalid GoogleIdToken
      - [x] Deploy to Dev - test route is working with PA