### PR TITLE
Deprecate OneSignal as used in Clients (Alert API Key, Responder Push ID) (CU-86dqkmhza)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the code was deployed.
 ### Removed
 
 - OneSignal functionality (CU-86dqkmhza).
+- OneSignal remnants Alert API Key and Responder Push ID from database and dashboard (CU-86dqkmhza).
 
 ## [13.4.0] - 2023-12-14
 

--- a/server/db/040-deprecate-one-signal.sql
+++ b/server/db/040-deprecate-one-signal.sql
@@ -1,0 +1,35 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 40;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- Remove columns alert_api_key and responder_push_id from clients
+        ALTER TABLE clients DROP COLUMN alert_api_key;
+        ALTER TABLE clients DROP COLUMN responder_push_id;
+
+	-- Where responder_phone_numbers is NULL, set it to an empty array
+	UPDATE clients
+	SET responder_phone_numbers = '{}'
+	WHERE responder_phone_numbers IS NULL;
+
+	-- Update responder_phone_numbers to not allow NULL values
+	ALTER TABLE clients 
+        ALTER COLUMN responder_phone_numbers SET NOT NULL;
+
+	-- Update responder_phone_numbers to have a default empty array value
+	ALTER TABLE clients
+	ALTER COLUMN responder_phone_numbers SET DEFAULT '{}';
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/db/040-deprecate-one-signal.sql
+++ b/server/db/040-deprecate-one-signal.sql
@@ -11,6 +11,10 @@ BEGIN
 
     -- Only execute this script if its migration ID is next after the last successful migration ID
     IF migrationId - lastSuccessfulMigrationId = 1 THEN
+    	-- Disable the set_clients_timestamp trigger so updated_at doesn't change
+	ALTER TABLE clients
+	DISABLE TRIGGER set_clients_timestamp;
+
         -- Remove columns alert_api_key and responder_push_id from clients
         ALTER TABLE clients DROP COLUMN alert_api_key;
         ALTER TABLE clients DROP COLUMN responder_push_id;
@@ -27,6 +31,10 @@ BEGIN
 	-- Update responder_phone_numbers to have a default empty array value
 	ALTER TABLE clients
 	ALTER COLUMN responder_phone_numbers SET DEFAULT '{}';
+
+    	-- Enable the set_clients_timestamp trigger now that the above queries have completed
+	ALTER TABLE clients
+	ENABLE TRIGGER set_clients_timestamp;
 
         -- Update the migration ID of the last file to be successfully run to the migration ID of this file
         INSERT INTO migrations (id)

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -33,7 +33,7 @@ function createSessionFromRow(r, allButtons) {
 
 function createClientFromRow(r) {
   // prettier-ignore
-  return new Client(r.id, r.display_name, r.responder_phone_numbers, r.responder_push_id, r.alert_api_key, r.reminder_timeout, r.fallback_phone_numbers, r.from_phone_number, r.fallback_timeout, r.heartbeat_phone_numbers, r.incident_categories, r.is_displayed, r.is_sending_alerts, r.is_sending_vitals, r.language, r.created_at, r.updated_at)
+  return new Client(r.id, r.display_name, r.responder_phone_numbers, r.reminder_timeout, r.fallback_phone_numbers, r.from_phone_number, r.fallback_timeout, r.heartbeat_phone_numbers, r.incident_categories, r.is_displayed, r.is_sending_alerts, r.is_sending_vitals, r.language, r.created_at, r.updated_at)
 }
 
 function createButtonFromRow(r, allClients) {
@@ -691,8 +691,6 @@ async function clearButtons(pgClient) {
 async function createClient(
   displayName,
   responderPhoneNumbers,
-  responderPushId,
-  alertApiKey,
   reminderTimeout,
   fallbackPhoneNumbers,
   fromPhoneNumber,
@@ -709,15 +707,13 @@ async function createClient(
     const results = await helpers.runQuery(
       'createClient',
       `
-      INSERT INTO clients (display_name, responder_phone_numbers, responder_push_id, alert_api_key, reminder_timeout, fallback_phone_numbers, from_phone_number, fallback_timeout, heartbeat_phone_numbers, incident_categories, is_displayed, is_sending_alerts, is_sending_vitals, language)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+      INSERT INTO clients (display_name, responder_phone_numbers, reminder_timeout, fallback_phone_numbers, from_phone_number, fallback_timeout, heartbeat_phone_numbers, incident_categories, is_displayed, is_sending_alerts, is_sending_vitals, language)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
       RETURNING *
       `,
       [
         displayName,
         responderPhoneNumbers,
-        responderPushId,
-        alertApiKey,
         reminderTimeout,
         fallbackPhoneNumbers,
         fromPhoneNumber,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-iot": "^3.360.0",
         "@aws-sdk/client-iot-wireless": "^3.360.0",
-        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#0a4a9c79d20f32d42d482caee0b9b85a69d2545b",
+        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v12.0.0",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "express": "^4.17.1",
@@ -2834,9 +2834,8 @@
       }
     },
     "node_modules/brave-alert-lib": {
-      "version": "11.0.1",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#0a4a9c79d20f32d42d482caee0b9b85a69d2545b",
-      "integrity": "sha512-+OzlffyNnQXyJ8X7CYtUPRFnl+jSZNcOJxMM2OFHNLocLmu0IibZ6xRIJuhLopHlTOkX5JL2jdr4ysDcKDMRtg==",
+      "version": "12.0.0",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#32529c6c7d772a45b1513dac0d678035d410c153",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aws-sdk/client-iot": "^3.360.0",
     "@aws-sdk/client-iot-wireless": "^3.360.0",
-    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#0a4a9c79d20f32d42d482caee0b9b85a69d2545b",
+    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v12.0.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumbersTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumbersTest.js
@@ -25,8 +25,6 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
       responderPhoneNumbers: this.installationResponderPhoneNumbers,
       fallbackPhoneNumbers: '{}',
       incidentCategories: this.installationIncidentCategories,
-      alertApiKey: null,
-      responderPushId: null,
       language: this.language,
     })
     const button = await buttonDBFactory(db, {

--- a/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
@@ -24,8 +24,6 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
       responderPhoneNumbers: this.installationResponderPhoneNumbers,
       fallbackPhoneNumbers: '{}',
       incidentCategories: this.installationIncidentCategories,
-      alertApiKey: null,
-      responderPushId: null,
       language: this.language,
     })
     const button = await buttonDBFactory(db, {

--- a/server/test/integration/serverTest.js
+++ b/server/test/integration/serverTest.js
@@ -70,8 +70,6 @@ describe('Chatbot server', () => {
         responderPhoneNumbers: installationResponderPhoneNumbers,
         fallbackPhoneNumbers: installationFallbackPhoneNumbers,
         incidentCategories: installationIncidentCategories,
-        alertApiKey: null,
-        responderPushId: null,
         reminderTimeout: 1,
         fallbackTimeout: 2,
         fromPhoneNumber: '+15005550006',


### PR DESCRIPTION
This PR removes the alert API key and responder push ID fields from clients. I.e., the respective columns in the database, as well as all factory calls to create or updates clients, are updated.

Test Plan:
- [x] Existing test cases pass
- [x] Several alerts can be generated from a test location, and chatbot works as expected
- [x] Logs look normal
- [x] Database migration scripts work as expected on the dev database