### PR TITLE
Disable and reject the reset chatbot flow if it occurs (CU-860r8k57h).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Changed
+
+- BraveAlerterConfigurator to reject the RESET state (CU-860r8k57h).
+
 ## [13.5.0] - 2023-01-04
 
 ### Removed

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -110,7 +110,7 @@ class BraveAlerterConfigurator {
             return {
               respondedByPhoneNumber: session.respondedByPhoneNumber,
               replacementReturnMessageToRespondedByPhoneNumber: null,
-              replacementReturnMessageToOtherResponderPhoneNumbers: null // Don't send a message to the other responder phone numbers
+              replacementReturnMessageToOtherResponderPhoneNumbers: null,
             }
           }
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-iot": "^3.360.0",
         "@aws-sdk/client-iot-wireless": "^3.360.0",
-        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v12.0.0",
+        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v12.1.1",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "express": "^4.17.1",
@@ -2834,8 +2834,8 @@
       }
     },
     "node_modules/brave-alert-lib": {
-      "version": "12.0.0",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#32529c6c7d772a45b1513dac0d678035d410c153",
+      "version": "12.1.1",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#8dc2b57a7979f706bcca629562c9bd6bea1dde94",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aws-sdk/client-iot": "^3.360.0",
     "@aws-sdk/client-iot-wireless": "^3.360.0",
-    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v12.0.0",
+    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v12.1.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "express": "^4.17.1",


### PR DESCRIPTION
This PR disables and rejects the reset chatbot flow. To do this, it has the `getClientMessageForResetMessage` argument to `BraveAlerter` return `null`, which disables the alert state machine transition from `STARTED` or `WAITING_FOR_REPLY` to `RESET`. The result is no change to the existing Buttons chatbot.

## Changelog

### Changed

- BraveAlerterConfigurator to reject the RESET state (CU-860r8k57h).

## Test plan

- [x] Existing test cases pass
- [x] Deploy to dev server
  - [x] Interaction with chatbot works as expected
    - [x] Initiate session with RAK button press, select incident category, end session
    - [x] The reset state is not entered, ever